### PR TITLE
Switch SHELL in makefile to `/usr/bin/env bash`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ FLOATING_POOL_NAME := floating-net
 
 INFRA_TEST_FLAGS   := --region='$(REGION)'
 
-SHELL=/bin/bash -e -o pipefail
+SHELL=/usr/bin/env bash -o pipefail
 
 #########################################
 # Tools                                 #


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:

We use currently `/bin/bash` which is not best practice. Lets use `/usr/bin/env bash` to use the bash which is in the env. 
Additionally this also removes the `-e` to not fail immediately after an error. 

This is now the same for example in [`gardener-extension-acl` ](https://github.com/stackitcloud/gardener-extension-acl/blob/84f96ea12072b14b22d5332bfeeb474697919d76/Makefile#L19) and [`gardener-extension-shoot-flux`](https://github.com/stackitcloud/gardener-extension-shoot-flux/blob/9888e6979ee6925b88138e798368390fb68fe49a/Makefile#L21)

