### PR TITLE
Fix saving the correct security group into the infra flow state

### DIFF
--- a/pkg/controller/infrastructure/stackit/infraflow/infraflow_suite_test.go
+++ b/pkg/controller/infrastructure/stackit/infraflow/infraflow_suite_test.go
@@ -1,0 +1,13 @@
+package infraflow
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestInfraflow(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "STACKIT Infraflow")
+}

--- a/pkg/controller/infrastructure/stackit/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/stackit/infraflow/reconcile.go
@@ -267,11 +267,17 @@ func (fctx *FlowContext) ensureSecGroup(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	emptyRules := []iaas.SecurityGroupRule{}
 	// Delete default egress rules
-	err = fctx.iaasClient.ReconcileSecurityGroupRules(ctx, log, created, []iaas.SecurityGroupRule{})
+	err = fctx.iaasClient.ReconcileSecurityGroupRules(ctx, log, created, emptyRules)
 	if err != nil {
 		return err
 	}
+
+	// clear rules on struct before saving in state
+	created.SetRules(emptyRules)
+
 	fctx.state.Set(IdentifierSecGroup, created.GetId())
 	fctx.state.Set(NameSecGroup, created.GetName())
 	fctx.state.SetObject(ObjectSecGroup, created)

--- a/pkg/controller/infrastructure/stackit/infraflow/reconcile_test.go
+++ b/pkg/controller/infrastructure/stackit/infraflow/reconcile_test.go
@@ -1,0 +1,87 @@
+package infraflow
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	iaas "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/controller/infrastructure/openstack/infraflow/shared"
+	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit"
+	mockclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit/client/mock"
+)
+
+var _ = Describe("STACKIT infraflow reconcile", func() {
+	Describe("#ensureSecGroup", func() {
+		var (
+			ctx      context.Context
+			ctrl     *gomock.Controller
+			mockIaaS *mockclient.MockIaaSClient
+			fctx     *FlowContext
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			ctrl = gomock.NewController(GinkgoT())
+			mockIaaS = mockclient.NewMockIaaSClient(ctrl)
+
+			fctx = &FlowContext{
+				state:       shared.NewWhiteboard(),
+				iaasClient:  mockIaaS,
+				technicalID: "shoot--foo--bar",
+			}
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		It("clears default egress rules before saving the security group in state", func() {
+			expectedPayload := iaas.CreateSecurityGroupPayload{
+				Name:        "shoot--foo--bar",
+				Description: new("Cluster Nodes"),
+			}
+			defaultEgressRules := []iaas.SecurityGroupRule{
+				{
+					Id:        new("default-egress-ipv4"),
+					Direction: stackit.DirectionEgress,
+					Ethertype: new(stackit.EtherTypeIPv4),
+				},
+				{
+					Id:        new("default-egress-ipv6"),
+					Direction: stackit.DirectionEgress,
+					Ethertype: new(stackit.EtherTypeIPv6),
+				},
+			}
+			createdSecurityGroup := &iaas.SecurityGroup{
+				Id:    new("security-group-id"),
+				Name:  "shoot--foo--bar",
+				Rules: defaultEgressRules,
+			}
+			expectedWantedRules := []iaas.SecurityGroupRule{}
+
+			mockIaaS.EXPECT().GetSecurityGroupByName(ctx, "shoot--foo--bar").Return([]iaas.SecurityGroup{}, nil)
+			mockIaaS.EXPECT().CreateSecurityGroup(ctx, expectedPayload).Return(createdSecurityGroup, nil)
+			mockIaaS.EXPECT().ReconcileSecurityGroupRules(ctx, gomock.Any(), createdSecurityGroup, expectedWantedRules).Return(nil)
+
+			err := fctx.ensureSecGroup(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(fctx.state.Get(IdentifierSecGroup)).ToNot(BeNil())
+			Expect(*fctx.state.Get(IdentifierSecGroup)).To(Equal("security-group-id"))
+			Expect(fctx.state.Get(NameSecGroup)).ToNot(BeNil())
+			Expect(*fctx.state.Get(NameSecGroup)).To(Equal("shoot--foo--bar"))
+
+			obj := fctx.state.GetObject(ObjectSecGroup)
+			Expect(obj).To(BeAssignableToTypeOf(&iaas.SecurityGroup{}))
+
+			savedSecurityGroup, ok := obj.(*iaas.SecurityGroup)
+			Expect(ok).To(BeTrue())
+			Expect(savedSecurityGroup.GetId()).To(Equal("security-group-id"))
+			Expect(savedSecurityGroup.GetName()).To(Equal("shoot--foo--bar"))
+			Expect(savedSecurityGroup.GetRules()).To(BeEmpty())
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
The Security Group Rules get cleared but the struct that is saved in the state still has the old rules on it. When reconciling the Security Group Rules, the egress rules are not getting created since the code assumes they are already present since it just fetches the security group from the state.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
