### PR TITLE
Add cloudprovider hash as annotation to STACKIT CSI

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -477,6 +477,7 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	checksums[openstack.CloudProviderCSIDiskConfigName] = gardenerutils.ComputeChecksum(cpDiskConfigSecret.Data)
 	credentials, _ := vp.getCredentials(ctx, cp) // ignore missing credentials
 
+	// TODO: The comment says ignore, but is this actually ignored?! If the secret can't be retrieved??? Same as above.
 	stackitCredentials, err := vp.getSTACKITCredentials(ctx, cp) // ignore missing credentials
 	if err != nil {
 		return nil, fmt.Errorf("getting STACKIT credentials: %w", err)
@@ -970,6 +971,7 @@ func getCSISTACKITControllerChartValues(cluster *extensionscontroller.Cluster, c
 		"replicas":  extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
 		"podAnnotations": map[string]any{
 			"checksum/secret-" + openstack.CloudProviderCSIDiskConfigName: checksums[openstack.CloudProviderCSIDiskConfigName],
+			"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
 		},
 		"csiSnapshotController": map[string]any{
 			"replicas": extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -477,8 +477,7 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	checksums[openstack.CloudProviderCSIDiskConfigName] = gardenerutils.ComputeChecksum(cpDiskConfigSecret.Data)
 	credentials, _ := vp.getCredentials(ctx, cp) // ignore missing credentials
 
-	// TODO: The comment says ignore, but is this actually ignored?! If the secret can't be retrieved??? Same as above.
-	stackitCredentials, err := vp.getSTACKITCredentials(ctx, cp) // ignore missing credentials
+	stackitCredentials, err := vp.getSTACKITCredentials(ctx, cp)
 	if err != nil {
 		return nil, fmt.Errorf("getting STACKIT credentials: %w", err)
 	}

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -555,6 +555,7 @@ var _ = Describe("ValuesProvider", func() {
 					"replicas": 1,
 					"podAnnotations": map[string]any{
 						"checksum/secret-" + openstack.CloudProviderCSIDiskConfigName: checksums[openstack.CloudProviderCSIDiskConfigName],
+						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
 					},
 					"projectID":         string(cpSecret.Data[stackit.ProjectID]),
 					"region":            "eu01",


### PR DESCRIPTION
**How to categorize this PR?**


/kind enhancement

**What this PR does / why we need it**:

Should add the hash of the `cloudprovider` secret to the CSI Deployment in the control-plane. Changes to the secret then will automatically recreate the deployment so the key in the application can be updated.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
