### PR TITLE
refactor registryCache mirror code into exported type

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -31,13 +31,14 @@ import (
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/feature"
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/openstack"
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit"
+	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/webhook/controlplane/registrycache"
 )
 
 // NewEnsurer creates a new controlplane ensurer.
 func NewEnsurer(regCaches []config.RegistryCacheConfiguration, logger logr.Logger) genericmutator.Ensurer {
 	return &ensurer{
 		logger: logger.WithName("openstack-controlplane-ensurer"),
-		regCacheEnsurer: &RegistryCacheMirrorEnsurer{
+		regCacheEnsurer: &registrycache.Ensurer{
 			Caches: regCaches,
 		},
 	}
@@ -46,7 +47,7 @@ func NewEnsurer(regCaches []config.RegistryCacheConfiguration, logger logr.Logge
 type ensurer struct {
 	genericmutator.NoopEnsurer
 	logger          logr.Logger
-	regCacheEnsurer *RegistryCacheMirrorEnsurer
+	regCacheEnsurer *registrycache.Ensurer
 }
 
 // ImageVector is exposed for testing.

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -36,15 +36,17 @@ import (
 // NewEnsurer creates a new controlplane ensurer.
 func NewEnsurer(regCaches []config.RegistryCacheConfiguration, logger logr.Logger) genericmutator.Ensurer {
 	return &ensurer{
-		logger:    logger.WithName("openstack-controlplane-ensurer"),
-		regCaches: regCaches,
+		logger: logger.WithName("openstack-controlplane-ensurer"),
+		regCacheEnsurer: &RegistryCacheMirrorEnsurer{
+			Caches: regCaches,
+		},
 	}
 }
 
 type ensurer struct {
 	genericmutator.NoopEnsurer
-	logger    logr.Logger
-	regCaches []config.RegistryCacheConfiguration
+	logger          logr.Logger
+	regCacheEnsurer *RegistryCacheMirrorEnsurer
 }
 
 // ImageVector is exposed for testing.
@@ -286,12 +288,12 @@ ExecStart=/opt/bin/update-resolv-conf.sh
 }
 
 func (e *ensurer) EnsureAdditionalProvisionFiles(ctx context.Context, gctx gcontext.GardenContext, newObj, _ *[]extensionsv1alpha1.File) error {
-	return e.ensureAdditionalFilesForRegCaches(newObj)
+	return e.regCacheEnsurer.EnsureCaches(newObj)
 }
 
 // EnsureAdditionalFiles ensures that additional required system files are added.
 func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gctx gcontext.GardenContext, newObj, _ *[]extensionsv1alpha1.File) error {
-	if err := e.ensureAdditionalFilesForRegCaches(newObj); err != nil {
+	if err := e.regCacheEnsurer.EnsureCaches(newObj); err != nil {
 		return err
 	}
 	cloudProfileConfig, err := getCloudProfileConfig(ctx, gctx)

--- a/pkg/webhook/controlplane/registry_cache.go
+++ b/pkg/webhook/controlplane/registry_cache.go
@@ -13,9 +13,13 @@ import (
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/apis/config"
 )
 
-// ensureAdditionalFilesForRegCaches for the hosts config and optionally a custom CA.
-func (e *ensurer) ensureAdditionalFilesForRegCaches(files *[]extensionsv1alpha1.File) error {
-	for _, reg := range e.regCaches {
+type RegistryCacheMirrorEnsurer struct {
+	Caches []config.RegistryCacheConfiguration
+}
+
+// EnsureCaches ensures the containerd hosts config and optionally a custom CA .
+func (e *RegistryCacheMirrorEnsurer) EnsureCaches(files *[]extensionsv1alpha1.File) error {
+	for _, reg := range e.Caches {
 		if err := ensureHostsConfig(reg, files); err != nil {
 			return err
 		}

--- a/pkg/webhook/controlplane/registrycache/registry_cache.go
+++ b/pkg/webhook/controlplane/registrycache/registry_cache.go
@@ -1,4 +1,4 @@
-package controlplane
+package registrycache
 
 import (
 	"fmt"
@@ -13,12 +13,12 @@ import (
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/apis/config"
 )
 
-type RegistryCacheMirrorEnsurer struct {
+type Ensurer struct {
 	Caches []config.RegistryCacheConfiguration
 }
 
 // EnsureCaches ensures the containerd hosts config and optionally a custom CA .
-func (e *RegistryCacheMirrorEnsurer) EnsureCaches(files *[]extensionsv1alpha1.File) error {
+func (e *Ensurer) EnsureCaches(files *[]extensionsv1alpha1.File) error {
 	for _, reg := range e.Caches {
 		if err := ensureHostsConfig(reg, files); err != nil {
 			return err

--- a/pkg/webhook/controlplane/registrycache/registry_cache_test.go
+++ b/pkg/webhook/controlplane/registrycache/registry_cache_test.go
@@ -1,13 +1,9 @@
-package controlplane
+package registrycache
 
 import (
-	"context"
 	"encoding/base64"
 
-	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
-	gcontext "github.com/gardener/gardener/extensions/pkg/webhook/context"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -16,19 +12,11 @@ import (
 
 var _ = Describe("registry cache files", func() {
 	var (
-		ctx  context.Context
-		gctx gcontext.GardenContext
-		log  logr.Logger
-
 		regCaches []config.RegistryCacheConfiguration
 		files     []extensionsv1alpha1.File
 	)
 
 	BeforeEach(func() {
-		ctx = context.Background()
-		gctx = &fakeGardenContext{}
-		log = logr.Discard()
-
 		regCaches = []config.RegistryCacheConfiguration{{
 			Server:       "https://foo.com",
 			Cache:        "https://foo-cache.com",
@@ -38,18 +26,20 @@ var _ = Describe("registry cache files", func() {
 	})
 
 	It("should not add anything with an empty list (AdditionalProvisionFiles)", func() {
-		e := NewEnsurer(nil, log)
+		e := &Ensurer{}
 
-		Expect(e.EnsureAdditionalProvisionFiles(ctx, gctx, &files, nil)).To(Succeed())
+		Expect(e.EnsureCaches(&files)).To(Succeed())
 		Expect(files).NotTo(ContainElement(
 			HaveField("Path", ContainSubstring("hosts.toml")),
 		))
 	})
 
 	It("should inject the config without CA (AdditionalProvisionFiles)", func() {
-		e := NewEnsurer(regCaches, log)
+		e := &Ensurer{
+			Caches: regCaches,
+		}
 
-		Expect(e.EnsureAdditionalProvisionFiles(ctx, gctx, &files, nil)).To(Succeed())
+		Expect(e.EnsureCaches(&files)).To(Succeed())
 
 		expetedData := `# Created by gardener-extension-provider-stackit
 server = 'https://foo.com'
@@ -71,9 +61,11 @@ capabilities = ['pull']
 		dummyCA := []byte("--- Certificate_---\nfoo\nbar")
 		regCaches[0].CABundle = dummyCA
 		encoded := base64.StdEncoding.EncodeToString(dummyCA)
-		e := NewEnsurer(regCaches, log)
+		e := &Ensurer{
+			Caches: regCaches,
+		}
 
-		Expect(e.EnsureAdditionalFiles(ctx, gctx, &files, nil)).To(Succeed())
+		Expect(e.EnsureCaches(&files)).To(Succeed())
 
 		Expect(files).To(ContainElements(
 			And(
@@ -90,10 +82,3 @@ capabilities = ['pull']
 		))
 	})
 })
-
-type fakeGardenContext struct {
-}
-
-func (f *fakeGardenContext) GetCluster(ctx context.Context) (*extensionscontroller.Cluster, error) {
-	return &extensionscontroller.Cluster{}, nil
-}


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:
Allows to reuse the registry-cache implementation from outside this module. 

**Special notes for your reviewer**:
/cc @dergeberl 

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
