### PR TITLE
fix: Add nlb.admin for exposure integration test SA

### DIFF
--- a/test/project-wrapper/sdk/util.go
+++ b/test/project-wrapper/sdk/util.go
@@ -8,6 +8,7 @@ import (
 var ServiceAccountRoles = []string{
 	"iaas.isolated-network.admin", // required by the infra controller
 	"iaas.network.admin",          // required by the infra controller
+	"nlb.admin",                   // required by the SelfHostedShootExposure controller
 }
 
 func GetMembersForRoles(subject string, roles set.Set[string]) []authorization.Member {


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
In order to run the newly added `SelfHostedShootExposure` integration tests in https://github.com/stackitcloud/gardener-extension-provider-stackit/pull/103, which use a dynamically created ServiceAccount with minimal roles (rather than full permissions), we need to add `nlb.admin` to the `ske-intgrtn-tst` SA (next to the existing and also needed IaaS Networking permissions).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
You may check the current failure in https://github.com/stackitcloud/gardener-extension-provider-stackit/pull/150 (403 on load balancer calls).
-> Also the integration test work with the changes (in this PR).

/cc @stackitcloud/ske-infrastructure 