### PR TITLE
Remove fork from mcm provider openstack and use newest release

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -90,7 +90,6 @@
       matchPackageNames: [
         'europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager-provider-openstack',
       ],
-      ignoreUnstable: false,
     },
     {
       groupName: 'Internal',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -86,12 +86,6 @@
       ],
     },
     {
-      groupName: 'machine-controller-manager-provider-openstack',
-      matchPackageNames: [
-        'europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager-provider-openstack',
-      ],
-    },
-    {
       groupName: 'Internal',
       matchFileNames: [
         'charts/internal/**/requirements.yaml',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -88,9 +88,8 @@
     {
       groupName: 'machine-controller-manager-provider-openstack',
       matchPackageNames: [
-        'registry.ske.stackit.cloud/stackitcloud/machine-controller-manager-provider-openstack',
+        'europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager-provider-openstack',
       ],
-      // Enable updating fork releases/tags, e.g., v0.24.1-ske-1
       ignoreUnstable: false,
     },
     {

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -44,8 +44,8 @@ images:
 
 - name: machine-controller-manager-provider-openstack
   sourceRepository: github.com/gardener/machine-controller-manager-provider-openstack
-  repository: registry.ske.stackit.cloud/stackitcloud/machine-controller-manager-provider-openstack
-  tag: "v0.25.0-ske-1"
+  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager-provider-openstack
+  tag: "v0.27.0"
 - name: machine-controller-manager-provider-stackit
   sourceRepository: github.com/stackitcloud/machine-controller-manager-provider-stackit
   repository: ghcr.io/stackitcloud/machine-controller-manager-provider-stackit

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -98,6 +98,11 @@ func (e *ensurer) EnsureMachineControllerManagerDeployment(ctx context.Context, 
 		}
 	}
 
+	sidecarContainer.Command = extensionswebhook.EnsureStringWithPrefix(
+		sidecarContainer.Command,
+		"--resource-exhausted-retry=", "20m",
+	)
+
 	newObj.Spec.Template.Spec.Containers = extensionswebhook.EnsureContainerWithName(
 		newObj.Spec.Template.Spec.Containers,
 		sidecarContainer,

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -98,10 +98,12 @@ func (e *ensurer) EnsureMachineControllerManagerDeployment(ctx context.Context, 
 		}
 	}
 
-	sidecarContainer.Args = extensionswebhook.EnsureStringWithPrefix(
-		sidecarContainer.Args,
-		"--resource-exhausted-retry=", "20m",
-	)
+	if !feature.UseStackitMachineControllerManager(cluster) {
+		sidecarContainer.Args = extensionswebhook.EnsureStringWithPrefix(
+			sidecarContainer.Args,
+			"--resource-exhausted-retry=", "20m",
+		)
+	}
 
 	newObj.Spec.Template.Spec.Containers = extensionswebhook.EnsureContainerWithName(
 		newObj.Spec.Template.Spec.Containers,

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -98,8 +98,8 @@ func (e *ensurer) EnsureMachineControllerManagerDeployment(ctx context.Context, 
 		}
 	}
 
-	sidecarContainer.Command = extensionswebhook.EnsureStringWithPrefix(
-		sidecarContainer.Command,
+	sidecarContainer.Args = extensionswebhook.EnsureStringWithPrefix(
+		sidecarContainer.Args,
 		"--resource-exhausted-retry=", "20m",
 	)
 

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -98,12 +98,12 @@ func (e *ensurer) EnsureMachineControllerManagerDeployment(ctx context.Context, 
 		}
 	}
 
-	if !feature.UseStackitMachineControllerManager(cluster) {
-		sidecarContainer.Args = extensionswebhook.EnsureStringWithPrefix(
-			sidecarContainer.Args,
-			"--resource-exhausted-retry=", "30m",
-		)
-	}
+	// avoid unnecessary reconciles if a recourse exhausted. Specially needed for machine-controller-manager-provider-openstack
+	// to avoid the creation of many volumes. But also on machine-controller-manager-provider-stackit this limits the amount of requests.
+	sidecarContainer.Args = extensionswebhook.EnsureStringWithPrefix(
+		sidecarContainer.Args,
+		"--resource-exhausted-retry=", "30m",
+	)
 
 	newObj.Spec.Template.Spec.Containers = extensionswebhook.EnsureContainerWithName(
 		newObj.Spec.Template.Spec.Containers,

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -101,7 +101,7 @@ func (e *ensurer) EnsureMachineControllerManagerDeployment(ctx context.Context, 
 	if !feature.UseStackitMachineControllerManager(cluster) {
 		sidecarContainer.Args = extensionswebhook.EnsureStringWithPrefix(
 			sidecarContainer.Args,
-			"--resource-exhausted-retry=", "20m",
+			"--resource-exhausted-retry=", "30m",
 		)
 	}
 

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -533,7 +533,7 @@ WantedBy=multi-user.target
 			Expect(ensurer.EnsureMachineControllerManagerDeployment(context.TODO(), eContextK8s127, deployment, nil)).To(Succeed())
 			expectedContainer := machinecontrollermanager.ProviderSidecarContainer(shoot, deployment.Namespace, "provider-openstack", "foo:bar")
 			expectedContainer.Args = extensionswebhook.EnsureStringWithPrefix(
-				expectedContainer.Args, "--resource-exhausted-retry=", "20m",
+				expectedContainer.Args, "--resource-exhausted-retry=", "30m",
 			)
 			Expect(deployment.Spec.Template.Spec.Containers).To(ConsistOf(expectedContainer))
 		})

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -532,6 +532,9 @@ WantedBy=multi-user.target
 			Expect(deployment.Spec.Template.Spec.Containers).To(BeEmpty())
 			Expect(ensurer.EnsureMachineControllerManagerDeployment(context.TODO(), eContextK8s127, deployment, nil)).To(Succeed())
 			expectedContainer := machinecontrollermanager.ProviderSidecarContainer(shoot, deployment.Namespace, "provider-openstack", "foo:bar")
+			expectedContainer.Args = extensionswebhook.EnsureStringWithPrefix(
+				expectedContainer.Args, "--resource-exhausted-retry=", "20m",
+			)
 			Expect(deployment.Spec.Template.Spec.Containers).To(ConsistOf(expectedContainer))
 		})
 	})

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -577,6 +577,9 @@ WantedBy=multi-user.target
 			Expect(ensurer.EnsureMachineControllerManagerDeployment(context.TODO(), eContextK8s127WithSTACKITMCM, deployment, nil)).To(Succeed())
 			expectedContainer := machinecontrollermanager.ProviderSidecarContainer(shoot, deployment.Namespace, "provider-stackit", "foo:bar")
 			expectedContainer.Env = []corev1.EnvVar{}
+			expectedContainer.Args = extensionswebhook.EnsureStringWithPrefix(
+				expectedContainer.Args, "--resource-exhausted-retry=", "30m",
+			)
 			Expect(deployment.Spec.Template.Spec.Containers).To(ConsistOf(expectedContainer))
 		})
 	})
@@ -628,6 +631,9 @@ WantedBy=multi-user.target
 					Value: "token.qa",
 				},
 			}
+			expectedContainer.Args = extensionswebhook.EnsureStringWithPrefix(
+				expectedContainer.Args, "--resource-exhausted-retry=", "30m",
+			)
 			Expect(deployment.Spec.Template.Spec.Containers).To(ConsistOf(expectedContainer))
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement

**What this PR does / why we need it**:
We want to get rid of the fork for machine-controller-manager-provider-openstack, therefore the necessary changes were contributed upstream. See https://github.com/gardener/machine-controller-manager-provider-openstack/releases/tag/v0.27.0

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**: