### PR TITLE
fix: Use BuildResourceName to build a valid DNS1123 compliant bastion name

### DIFF
--- a/pkg/controller/bastion/options.go
+++ b/pkg/controller/bastion/options.go
@@ -10,6 +10,7 @@ import (
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	stackitclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit/client"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/apis/stackit/helper"
@@ -43,10 +44,16 @@ type Options struct {
 }
 
 func (a *Actuator) DetermineOptions(ctx context.Context, bastion *extensionsv1alpha1.Bastion, cluster *extensionscontroller.Cluster, projectID string) (*Options, error) {
+
+	bastionName := fmt.Sprintf("%s-bastion-%s", cluster.Shoot.Status.TechnicalID, bastion.Name)
+	if len(bastionName) > 63 {
+		bastionName = stackitclient.BuildResourceName(cluster.Shoot.Status.TechnicalID, "-bastion-", bastion.Name)
+	}
+
 	opts := &Options{
 		Bastion:      bastion,
 		ProjectID:    projectID,
-		ResourceName: fmt.Sprintf("%s-bastion-%s", cluster.Shoot.Status.TechnicalID, bastion.Name),
+		ResourceName: bastionName,
 		Labels: map[string]string{
 			utils.ClusterLabelKey(a.CustomLabelDomain):          cluster.Shoot.Status.TechnicalID,
 			utils.BuildLabelKey(a.CustomLabelDomain, "bastion"): bastion.Name,

--- a/pkg/controller/bastion/options.go
+++ b/pkg/controller/bastion/options.go
@@ -10,12 +10,12 @@ import (
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	stackitclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit/client"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/apis/stackit/helper"
 	stackitv1alpha1 "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/apis/stackit/v1alpha1"
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit"
+	stackitclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit/client"
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/utils"
 )
 
@@ -44,7 +44,6 @@ type Options struct {
 }
 
 func (a *Actuator) DetermineOptions(ctx context.Context, bastion *extensionsv1alpha1.Bastion, cluster *extensionscontroller.Cluster, projectID string) (*Options, error) {
-
 	bastionName := fmt.Sprintf("%s-bastion-%s", cluster.Shoot.Status.TechnicalID, bastion.Name)
 	if len(bastionName) > 63 {
 		bastionName = stackitclient.BuildResourceName(cluster.Shoot.Status.TechnicalID, "-bastion-", bastion.Name)

--- a/pkg/controller/bastion/options.go
+++ b/pkg/controller/bastion/options.go
@@ -44,15 +44,10 @@ type Options struct {
 }
 
 func (a *Actuator) DetermineOptions(ctx context.Context, bastion *extensionsv1alpha1.Bastion, cluster *extensionscontroller.Cluster, projectID string) (*Options, error) {
-	bastionName := fmt.Sprintf("%s-bastion-%s", cluster.Shoot.Status.TechnicalID, bastion.Name)
-	if len(bastionName) > 63 {
-		bastionName = stackitclient.BuildResourceName(cluster.Shoot.Status.TechnicalID, "-bastion-", bastion.Name)
-	}
-
 	opts := &Options{
 		Bastion:      bastion,
 		ProjectID:    projectID,
-		ResourceName: bastionName,
+		ResourceName: stackitclient.BuildResourceName(cluster.Shoot.Status.TechnicalID, "-bastion-", bastion.Name),
 		Labels: map[string]string{
 			utils.ClusterLabelKey(a.CustomLabelDomain):          cluster.Shoot.Status.TechnicalID,
 			utils.BuildLabelKey(a.CustomLabelDomain, "bastion"): bastion.Name,

--- a/pkg/controller/bastion/options_test.go
+++ b/pkg/controller/bastion/options_test.go
@@ -9,7 +9,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	stackitclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit/client"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -250,16 +249,18 @@ var _ = Describe("Options", func() {
 			WorkerSecurityGroupID: "security-group-id-nodes",
 		}))
 	})
-	It("should correctly generate a valid bastion name", func() {
-		shoot.Status.TechnicalID = "something-very-very-very-very-very-very-very-very-long"
-		bastionName := stackitclient.BuildResourceName(shoot.Status.TechnicalID, "-bastion-", bastion.Name)
-		Expect(a.DetermineOptions(ctx, bastion, cluster, projectID)).To(Equal(&Options{
+	It("should correctly generate a valid bastion name if length is more than 63", func() {
+		shoot.Status.TechnicalID = "shoot--982656e3f6--e2e-6oy241v"
+		bastion.Name = "e2e-6oy241v-private-cluster"
+		result, err := a.DetermineOptions(ctx, bastion, cluster, projectID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(&Options{
 			Bastion:      bastion,
 			ProjectID:    projectID,
-			ResourceName: bastionName,
+			ResourceName: "shoot--982656e3f6--e2e-6oy241v-bastion-e2e-6oy241v-pri-861f41cc",
 			Labels: map[string]string{
-				"kubernetes.io/cluster": "something-very-very-very-very-very-very-very-very-long",
-				"kubernetes.io/bastion": "foo",
+				"kubernetes.io/cluster": "shoot--982656e3f6--e2e-6oy241v",
+				"kubernetes.io/bastion": "e2e-6oy241v-private-cluster",
 			},
 			Region:                "eu01",
 			AvailabilityZone:      "eu01-1",
@@ -268,6 +269,7 @@ var _ = Describe("Options", func() {
 			NetworkID:             "network-id",
 			WorkerSecurityGroupID: "security-group-id-nodes",
 		}))
+		Expect(result.ResourceName).To(HaveLen(63))
 	})
 
 	DescribeTable("customLabelDomain for bastion labels",

--- a/pkg/controller/bastion/options_test.go
+++ b/pkg/controller/bastion/options_test.go
@@ -9,6 +9,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	stackitclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit/client"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -239,6 +240,25 @@ var _ = Describe("Options", func() {
 			ResourceName: "shoot--garden--hops-bastion-foo",
 			Labels: map[string]string{
 				"kubernetes.io/cluster": "shoot--garden--hops",
+				"kubernetes.io/bastion": "foo",
+			},
+			Region:                "eu01",
+			AvailabilityZone:      "eu01-1",
+			MachineType:           "c1i.2",
+			ImageID:               "eu01-flatcar-1.1.0",
+			NetworkID:             "network-id",
+			WorkerSecurityGroupID: "security-group-id-nodes",
+		}))
+	})
+	It("should correctly generate a valid bastion name", func() {
+		shoot.Status.TechnicalID = "something-very-very-very-very-very-very-very-very-long"
+		bastionName := stackitclient.BuildResourceName(shoot.Status.TechnicalID, "-bastion-", bastion.Name)
+		Expect(a.DetermineOptions(ctx, bastion, cluster, projectID)).To(Equal(&Options{
+			Bastion:      bastion,
+			ProjectID:    projectID,
+			ResourceName: bastionName,
+			Labels: map[string]string{
+				"kubernetes.io/cluster": "something-very-very-very-very-very-very-very-very-long",
 				"kubernetes.io/bastion": "foo",
 			},
 			Region:                "eu01",

--- a/pkg/controller/selfhostedshootexposure/options.go
+++ b/pkg/controller/selfhostedshootexposure/options.go
@@ -3,12 +3,10 @@ package selfhostedshootexposure
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	gardenerutils "github.com/gardener/gardener/pkg/utils"
-	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
+	stackitclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit/client"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -24,10 +22,6 @@ const (
 
 	// resourceNameInfix separates the technical ID from the exposure name in the LB resource name.
 	resourceNameInfix = "-exp-"
-	// resourceNameHashLength is the number of hex chars from SHA-256(exposure.Name) appended when
-	// the unabridged name would exceed validation.DNS1123LabelMaxLength. 8 hex chars = 32 bits,
-	// plenty of collision resistance for "names sharing a prefix on the same shoot".
-	resourceNameHashLength = 8
 )
 
 // Options contains all input required for creating a STACKIT LB for a self-hosted shoot on STACKIT.
@@ -57,7 +51,7 @@ func (a *Actuator) DetermineOptions(ctx context.Context, exposure *extensionsv1a
 	opts := &Options{
 		SelfHostedShootExposure: exposure,
 		ProjectID:               projectID,
-		ResourceName:            buildResourceName(cluster.Shoot.Status.TechnicalID, exposure.Name),
+		ResourceName:            stackitclient.BuildResourceName(cluster.Shoot.Status.TechnicalID, resourceNameInfix, exposure.Name),
 		// STACKIT LB labels do not allow '/' in keys, so we use the flat dot-separated form
 		// matching the convention used for other STACKIT LBs (CCM extraLabels in
 		// controlplane.valuesprovider, infrastructure cleanup in infraflow/delete.go).
@@ -98,22 +92,6 @@ func (a *Actuator) DetermineOptions(ctx context.Context, exposure *extensionsv1a
 	}
 
 	return opts, nil
-}
-
-// buildResourceName returns "<technicalID>-exp-<exposureName>" if it fits within
-// apivalidation.DNS1123LabelMaxLength, otherwise truncates the exposure name and appends an
-// 8-char SHA-256 suffix of the original exposure name to keep the result unique and DNS-compliant.
-func buildResourceName(technicalID, exposureName string) string {
-	full := technicalID + resourceNameInfix + exposureName
-	if len(full) <= utilvalidation.DNS1123LabelMaxLength {
-		return full
-	}
-
-	hash := gardenerutils.ComputeSHA256Hex([]byte(exposureName))[:resourceNameHashLength]
-	budget := max(0, utilvalidation.DNS1123LabelMaxLength-len(technicalID)-len(resourceNameInfix)-resourceNameHashLength-1)
-	// strings.TrimRight strips trailing hyphens after truncation to keep the result DNS-1123 compliant.
-	truncated := strings.TrimRight(exposureName[:budget], "-")
-	return technicalID + resourceNameInfix + truncated + "-" + hash
 }
 
 func getInfrastructureStatus(ctx context.Context, c client.Client, cluster *extensionscontroller.Cluster) (*stackitv1alpha1.InfrastructureStatus, error) {

--- a/pkg/controller/selfhostedshootexposure/options.go
+++ b/pkg/controller/selfhostedshootexposure/options.go
@@ -6,7 +6,6 @@ import (
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	stackitclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit/client"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/apis/stackit/validation"
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/controller/controlplane"
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit"
+	stackitclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit/client"
 )
 
 const (

--- a/pkg/stackit/client/utils.go
+++ b/pkg/stackit/client/utils.go
@@ -1,0 +1,31 @@
+package client
+
+import (
+	"strings"
+
+	gardenerutils "github.com/gardener/gardener/pkg/utils"
+	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
+)
+
+const (
+	// resourceNameHashLength is the number of hex chars from SHA-256(exposure.Name) appended when
+	// the unabridged name would exceed validation.DNS1123LabelMaxLength. 8 hex chars = 32 bits,
+	// plenty of collision resistance for "names sharing a prefix on the same shoot".
+	resourceNameHashLength = 8
+)
+
+// BuildResourceName returns "<technicalID>-<resourceNameInfix>-<resourceName>" if it fits within
+// apivalidation.DNS1123LabelMaxLength, otherwise truncates the exposure name and appends an
+// 8-char SHA-256 suffix of the original exposure name to keep the result unique and DNS-compliant.
+func BuildResourceName(technicalID, resourceNameInfix, resourceName string) string {
+	full := technicalID + resourceNameInfix + resourceName
+	if len(full) <= utilvalidation.DNS1123LabelMaxLength {
+		return full
+	}
+
+	hash := gardenerutils.ComputeSHA256Hex([]byte(resourceName))[:resourceNameHashLength]
+	budget := max(0, utilvalidation.DNS1123LabelMaxLength-len(technicalID)-len(resourceNameInfix)-resourceNameHashLength-1)
+	// strings.TrimRight strips trailing hyphens after truncation to keep the result DNS-1123 compliant.
+	truncated := strings.TrimRight(resourceName[:budget], "-")
+	return technicalID + resourceNameInfix + truncated + "-" + hash
+}

--- a/pkg/stackit/client/utils.go
+++ b/pkg/stackit/client/utils.go
@@ -8,15 +8,15 @@ import (
 )
 
 const (
-	// resourceNameHashLength is the number of hex chars from SHA-256(exposure.Name) appended when
+	// resourceNameHashLength is the number of hex chars from SHA-256 appended when
 	// the unabridged name would exceed validation.DNS1123LabelMaxLength. 8 hex chars = 32 bits,
 	// plenty of collision resistance for "names sharing a prefix on the same shoot".
 	resourceNameHashLength = 8
 )
 
 // BuildResourceName returns "<technicalID>-<resourceNameInfix>-<resourceName>" if it fits within
-// apivalidation.DNS1123LabelMaxLength, otherwise truncates the exposure name and appends an
-// 8-char SHA-256 suffix of the original exposure name to keep the result unique and DNS-compliant.
+// apivalidation.DNS1123LabelMaxLength, otherwise truncates the resource name and appends an
+// 8-char SHA-256 suffix of the original resourceName name to keep the result unique and DNS-compliant.
 func BuildResourceName(technicalID, resourceNameInfix, resourceName string) string {
 	full := technicalID + resourceNameInfix + resourceName
 	if len(full) <= utilvalidation.DNS1123LabelMaxLength {


### PR DESCRIPTION
**How to categorize this PR?**

/kind bug

**What this PR does / why we need it**:

The generated bastionName can be bigger than allowed (max 63 characters). Therefore we introduce the same mechanism as in the exposure classes for the generation of the bastionName.

This PR makes the `BuildResourceName` a bit more generic and moves the helper function to the stackit client package.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
