### PR TITLE
remove region env var and retrieve from config instead

### DIFF
--- a/charts/internal/seed-controlplane/charts/stackit-blockstorage-csi-driver/templates/deployment-csi-driver-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/stackit-blockstorage-csi-driver/templates/deployment-csi-driver-controller.yaml
@@ -61,11 +61,6 @@ spec:
         - name: STACKIT_TOKEN_BASEURL
           value: {{ .Values.stackitEndpoints.tokenUrl }}
         {{- end }}
-        {{- if .Values.region }}
-        # TODO: later remove this
-        - name: STACKIT_REGION
-          value: {{ .Values.region }}
-        {{- end }}
 {{- if .Values.resources.driver }}
         resources:
 {{ toYaml .Values.resources.driver | indent 10 }}


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:

This PR removed the region from the deployment environment variable because CSI retrieves it from config instead.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

should be meged with https://github.com/stackitcloud/cloud-provider-stackit/pull/1244 @breuerfelix 

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
