### PR TITLE
revert: mcm-provider-openstack upstream due to bug in `v0.62` release

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -86,6 +86,14 @@
       ],
     },
     {
+      groupName: 'machine-controller-manager-provider-openstack',
+      matchPackageNames: [
+        'registry.ske.stackit.cloud/stackitcloud/machine-controller-manager-provider-openstack',
+      ],
+      // Enable updating fork releases/tags, e.g., v0.24.1-ske-1
+      ignoreUnstable: false,
+    },
+    {
       groupName: 'Internal',
       matchFileNames: [
         'charts/internal/**/requirements.yaml',

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -44,8 +44,8 @@ images:
 
 - name: machine-controller-manager-provider-openstack
   sourceRepository: github.com/gardener/machine-controller-manager-provider-openstack
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager-provider-openstack
-  tag: "v0.27.0"
+  repository: registry.ske.stackit.cloud/stackitcloud/machine-controller-manager-provider-openstack
+  tag: "v0.25.0-ske-1"
 - name: machine-controller-manager-provider-stackit
   sourceRepository: github.com/stackitcloud/machine-controller-manager-provider-stackit
   repository: ghcr.io/stackitcloud/machine-controller-manager-provider-stackit

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -98,13 +98,6 @@ func (e *ensurer) EnsureMachineControllerManagerDeployment(ctx context.Context, 
 		}
 	}
 
-	// avoid unnecessary reconciles if a recourse exhausted. Specially needed for machine-controller-manager-provider-openstack
-	// to avoid the creation of many volumes. But also on machine-controller-manager-provider-stackit this limits the amount of requests.
-	sidecarContainer.Args = extensionswebhook.EnsureStringWithPrefix(
-		sidecarContainer.Args,
-		"--resource-exhausted-retry=", "30m",
-	)
-
 	newObj.Spec.Template.Spec.Containers = extensionswebhook.EnsureContainerWithName(
 		newObj.Spec.Template.Spec.Containers,
 		sidecarContainer,

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -532,9 +532,6 @@ WantedBy=multi-user.target
 			Expect(deployment.Spec.Template.Spec.Containers).To(BeEmpty())
 			Expect(ensurer.EnsureMachineControllerManagerDeployment(context.TODO(), eContextK8s127, deployment, nil)).To(Succeed())
 			expectedContainer := machinecontrollermanager.ProviderSidecarContainer(shoot, deployment.Namespace, "provider-openstack", "foo:bar")
-			expectedContainer.Args = extensionswebhook.EnsureStringWithPrefix(
-				expectedContainer.Args, "--resource-exhausted-retry=", "30m",
-			)
 			Expect(deployment.Spec.Template.Spec.Containers).To(ConsistOf(expectedContainer))
 		})
 	})
@@ -577,9 +574,6 @@ WantedBy=multi-user.target
 			Expect(ensurer.EnsureMachineControllerManagerDeployment(context.TODO(), eContextK8s127WithSTACKITMCM, deployment, nil)).To(Succeed())
 			expectedContainer := machinecontrollermanager.ProviderSidecarContainer(shoot, deployment.Namespace, "provider-stackit", "foo:bar")
 			expectedContainer.Env = []corev1.EnvVar{}
-			expectedContainer.Args = extensionswebhook.EnsureStringWithPrefix(
-				expectedContainer.Args, "--resource-exhausted-retry=", "30m",
-			)
 			Expect(deployment.Spec.Template.Spec.Containers).To(ConsistOf(expectedContainer))
 		})
 	})
@@ -631,9 +625,6 @@ WantedBy=multi-user.target
 					Value: "token.qa",
 				},
 			}
-			expectedContainer.Args = extensionswebhook.EnsureStringWithPrefix(
-				expectedContainer.Args, "--resource-exhausted-retry=", "30m",
-			)
 			Expect(deployment.Spec.Template.Spec.Containers).To(ConsistOf(expectedContainer))
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug

**What this PR does / why we need it**:
A [pull request](https://github.com/gardener/machine-controller-manager/pull/1059) in mcm introduced machine preservation, where the node is checked even if there's no machine phase yet. And a missing node results in a `SKE_NODE_MACHINE_PHASE_MISSING` error.

Node cordoning does not work, we have problems with the deletion of machines that have no phase, and we have double VM creation also due to the preservation.

The pull request that is reverted temporarily here is https://github.com/stackitcloud/gardener-extension-provider-stackit/pull/161

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Breaking changes**:

