### PR TITLE
use fake client instead of mock client for tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -192,7 +192,6 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.80.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -192,6 +192,7 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
+	google.golang.org/grpc v1.80.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/pkg/controller/infrastructure/openstack/configvalidator_test.go
+++ b/pkg/controller/infrastructure/openstack/configvalidator_test.go
@@ -32,7 +32,6 @@ import (
 
 	stackitv1alpha1 "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/apis/stackit/v1alpha1"
 	. "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/controller/infrastructure/openstack"
-	mockclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/mock/controller-runtime/client"
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/openstack"
 	mockopenstackclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/openstack/client/mocks"
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit"

--- a/pkg/controller/infrastructure/openstack/configvalidator_test.go
+++ b/pkg/controller/infrastructure/openstack/configvalidator_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	stackitv1alpha1 "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/apis/stackit/v1alpha1"
@@ -52,7 +53,7 @@ const (
 var _ = Describe("ConfigValidator", func() {
 	var (
 		ctrl                          *gomock.Controller
-		c                             *mockclient.MockClient
+		c                             client.Client
 		mgr                           *testutils.FakeManager
 		openstackClientFactoryFactory *mockopenstackclient.MockFactoryFactory
 		openstackClientFactory        *mockopenstackclient.MockFactory
@@ -68,17 +69,12 @@ var _ = Describe("ConfigValidator", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 
-		c = mockclient.NewMockClient(ctrl)
 		openstackClientFactoryFactory = mockopenstackclient.NewMockFactoryFactory(ctrl)
 		openstackClientFactory = mockopenstackclient.NewMockFactory(ctrl)
 		networkingClient = mockopenstackclient.NewMockNetworking(ctrl)
 
 		ctx = context.TODO()
 		logger = log.Log.WithName("test")
-
-		mgr = &testutils.FakeManager{Client: c}
-
-		cv = NewConfigValidator(mgr, openstackClientFactoryFactory, logger)
 
 		infra = &extensionsv1alpha1.Infrastructure{
 			ObjectMeta: metav1.ObjectMeta{
@@ -122,6 +118,10 @@ var _ = Describe("ConfigValidator", func() {
 			Password:   password,
 			AuthURL:    authURL,
 		}
+
+		c = fakeclient.NewClientBuilder().WithObjects(secret.DeepCopy()).Build()
+		mgr = &testutils.FakeManager{Client: c}
+		cv = NewConfigValidator(mgr, openstackClientFactoryFactory, logger)
 	})
 
 	AfterEach(func() {
@@ -130,12 +130,6 @@ var _ = Describe("ConfigValidator", func() {
 
 	Describe("#Validate", func() {
 		BeforeEach(func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{namespace, name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-					*obj = *secret
-					return nil
-				},
-			)
 			openstackClientFactoryFactory.EXPECT().NewFactory(ctx, credentials).Return(openstackClientFactory, nil)
 			openstackClientFactory.EXPECT().Networking(gomock.Any()).Return(networkingClient, nil)
 		})

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -32,7 +32,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/charts"
 	stackitv1alpha1 "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/apis/stackit/v1alpha1"
@@ -47,8 +49,7 @@ var _ = Describe("Machines", func() {
 		ctx = context.Background()
 
 		ctrl         *gomock.Controller
-		c            *mockclient.MockClient
-		statusWriter *mockclient.MockStatusWriter
+		c            client.Client
 		chartApplier *mockkubernetes.MockChartApplier
 
 		workerDelegate genericworkeractuator.WorkerDelegate
@@ -58,12 +59,12 @@ var _ = Describe("Machines", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 
-		c = mockclient.NewMockClient(ctrl)
-		statusWriter = mockclient.NewMockStatusWriter(ctrl)
 		chartApplier = mockkubernetes.NewMockChartApplier(ctrl)
 
 		scheme = runtime.NewScheme()
-		_ = stackitv1alpha1.AddToScheme(scheme)
+		utilruntime.Must(corev1.AddToScheme(scheme))
+		utilruntime.Must(extensionsv1alpha1.AddToScheme(scheme))
+		utilruntime.Must(stackitv1alpha1.AddToScheme(scheme))
 	})
 
 	AfterEach(func() {
@@ -156,6 +157,14 @@ var _ = Describe("Machines", func() {
 
 				emptyClusterAutoscalerAnnotations map[string]string
 			)
+
+			newFakeClient := func(objects ...client.Object) client.Client {
+				return fakeclient.NewClientBuilder().
+					WithScheme(scheme).
+					WithStatusSubresource(&extensionsv1alpha1.Worker{}).
+					WithObjects(objects...).
+					Build()
+			}
 
 			BeforeEach(func() {
 				namespace = "control-plane-namespace"
@@ -297,6 +306,7 @@ var _ = Describe("Machines", func() {
 
 				w = &extensionsv1alpha1.Worker{
 					ObjectMeta: metav1.ObjectMeta{
+						Name:      "worker",
 						Namespace: namespace,
 					},
 					Spec: extensionsv1alpha1.WorkerSpec{
@@ -414,16 +424,31 @@ var _ = Describe("Machines", func() {
 				workerPoolHash2, _ = worker.WorkerPoolHash(w.Spec.Pools[1], cluster, nil, nil, nil)
 				workerPoolHash3, _ = worker.WorkerPoolHash(w.Spec.Pools[2], cluster, nil, nil, nil)
 
+				c = newFakeClient(
+					w.DeepCopy(),
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      userDataSecretName,
+							Namespace: namespace,
+						},
+						Data: map[string][]byte{userDataSecretDataKey: userData},
+					},
+				)
+
 				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, clusterWithoutImages, "")
 			})
 
-			expectedUserDataSecretRefRead := func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: userDataSecretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
-						secret.Data = map[string][]byte{userDataSecretDataKey: userData}
-						return nil
-					},
-				).AnyTimes()
+			expectWorkerStatus := func(workerObj *extensionsv1alpha1.Worker, expectedStatus *stackitv1alpha1.WorkerStatus) {
+				persistedWorker := &extensionsv1alpha1.Worker{}
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(workerObj), persistedWorker)).To(Succeed())
+				Expect(persistedWorker.Status.ProviderStatus).NotTo(BeNil())
+
+				rawStatus, err := persistedWorker.Status.GetProviderStatus().MarshalJSON()
+				Expect(err).NotTo(HaveOccurred())
+
+				actualStatus := &stackitv1alpha1.WorkerStatus{}
+				Expect(json.Unmarshal(rawStatus, actualStatus)).To(Succeed())
+				Expect(actualStatus).To(Equal(expectedStatus))
 			}
 
 			setupMachineTest := func(region, name, imageID, architecture string, useStackitMCM bool, defaultMachineClass *map[string]any, machineDeployments *worker.MachineDeployments, machineClasses *map[string]any, workerWithRegion **extensionsv1alpha1.Worker, clusterWithRegion **extensionscontroller.Cluster) {
@@ -471,6 +496,17 @@ var _ = Describe("Machines", func() {
 					Seed:         cluster.Seed,
 				}
 				(*clusterWithRegion).Shoot.Spec.Region = region
+
+				c = newFakeClient(
+					(*workerWithRegion).DeepCopy(),
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      userDataSecretName,
+							Namespace: namespace,
+						},
+						Data: map[string][]byte{userDataSecretDataKey: userData},
+					},
+				)
 
 				// For STACKIT, region is determined using DetermineRegion which handles RegionOne -> eu01 mapping
 				effectiveRegion := region
@@ -736,8 +772,6 @@ var _ = Describe("Machines", func() {
 					workerDelegate, _ := NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, "")
 
 					// Test workerDelegate.DeployMachineClasses()
-					expectedUserDataSecretRefRead()
-
 					chartApplier.
 						EXPECT().
 						ApplyFromEmbeddedFS(
@@ -775,11 +809,9 @@ var _ = Describe("Machines", func() {
 						Object: expectedImages,
 					}
 
-					c.EXPECT().Status().Return(statusWriter)
-					statusWriter.EXPECT().Patch(ctx, workerWithExpectedImages, gomock.Any()).Return(nil)
-
 					err = workerDelegate.UpdateMachineImagesStatus(ctx)
 					Expect(err).NotTo(HaveOccurred())
+					expectWorkerStatus(w, expectedImages)
 
 					// Test workerDelegate.GenerateMachineDeployments()
 
@@ -794,8 +826,6 @@ var _ = Describe("Machines", func() {
 					clusterWithRegion.Shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{Enabled: new(true)}
 
 					// Test workerDelegate.DeployMachineClasses()
-					expectedUserDataSecretRefRead()
-
 					chartApplier.
 						EXPECT().
 						ApplyFromEmbeddedFS(
@@ -832,12 +862,9 @@ var _ = Describe("Machines", func() {
 						Object: expectedImages,
 					}
 
-					ctx := ctx
-					c.EXPECT().Status().Return(statusWriter)
-					statusWriter.EXPECT().Patch(ctx, workerWithExpectedImages, gomock.Any()).Return(nil)
-
 					err = workerDelegate.UpdateMachineImagesStatus(ctx)
 					Expect(err).NotTo(HaveOccurred())
+					expectWorkerStatus(workerWithRegion, expectedImages)
 
 					// Test workerDelegate.GenerateMachineDeployments()
 
@@ -864,8 +891,6 @@ var _ = Describe("Machines", func() {
 								Raw: encode(workerConfig),
 							}
 							workerDelegate, _ := NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, "")
-
-							expectedUserDataSecretRefRead()
 
 							result, err := workerDelegate.GenerateMachineDeployments(ctx)
 							Expect(err).NotTo(HaveOccurred())
@@ -930,8 +955,6 @@ var _ = Describe("Machines", func() {
 					workerDelegate, _ := NewWorkerDelegate(c, scheme, chartApplier, "", workerWithRegion, clusterWithRegion, "kubernetes.io")
 
 					// Test workerDelegate.DeployMachineClasses()
-					expectedUserDataSecretRefRead()
-
 					chartApplier.
 						EXPECT().
 						ApplyFromEmbeddedFS(
@@ -968,11 +991,9 @@ var _ = Describe("Machines", func() {
 						Object: expectedImages,
 					}
 
-					c.EXPECT().Status().Return(statusWriter)
-					statusWriter.EXPECT().Patch(ctx, workerWithExpectedImages, gomock.Any()).Return(nil)
-
 					err = workerDelegate.UpdateMachineImagesStatus(ctx)
 					Expect(err).NotTo(HaveOccurred())
+					expectWorkerStatus(workerWithRegion, expectedImages)
 
 					// Test workerDelegate.GenerateMachineDeployments()
 					result, err := workerDelegate.GenerateMachineDeployments(ctx)
@@ -986,8 +1007,6 @@ var _ = Describe("Machines", func() {
 					clusterWithRegion.Shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{Enabled: new(true)}
 
 					// Test workerDelegate.DeployMachineClasses()
-					expectedUserDataSecretRefRead()
-
 					chartApplier.
 						EXPECT().
 						ApplyFromEmbeddedFS(
@@ -1024,11 +1043,9 @@ var _ = Describe("Machines", func() {
 						Object: expectedImages,
 					}
 
-					c.EXPECT().Status().Return(statusWriter)
-					statusWriter.EXPECT().Patch(ctx, workerWithExpectedImages, gomock.Any()).Return(nil)
-
 					err = workerDelegate.UpdateMachineImagesStatus(ctx)
 					Expect(err).NotTo(HaveOccurred())
+					expectWorkerStatus(workerWithRegion, expectedImages)
 
 					// Test workerDelegate.GenerateMachineDeployments()
 					result, err := workerDelegate.GenerateMachineDeployments(ctx)
@@ -1094,8 +1111,6 @@ var _ = Describe("Machines", func() {
 
 				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, "")
 
-				expectedUserDataSecretRefRead()
-
 				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				resultSettings := result[0].MachineConfiguration
 				resultNodeConditions := strings.Join(testNodeConditions, ",")
@@ -1118,8 +1133,6 @@ var _ = Describe("Machines", func() {
 				}
 				w.Spec.Pools[1].ClusterAutoscaler = nil
 				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, "")
-
-				expectedUserDataSecretRefRead()
 
 				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				Expect(err).NotTo(HaveOccurred())
@@ -1150,8 +1163,6 @@ var _ = Describe("Machines", func() {
 			DescribeTable("customLabelDomain in machineclass helm chart",
 				func(customDomain string) {
 					workerDelegate, _ := NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customDomain)
-
-					expectedUserDataSecretRefRead()
 
 					chartApplier.
 						EXPECT().
@@ -1196,15 +1207,6 @@ func useDefaultMachineClass(def map[string]any, value any) map[string]any {
 	maps.Copy(out, def)
 
 	out["availabilityZone"] = value
-	return out
-}
-
-func useDefaultMachineClassWith(def map[string]any, add map[string]any) map[string]any {
-	out := make(map[string]any, len(add))
-
-	maps.Copy(out, def)
-	maps.Copy(out, add)
-
 	return out
 }
 

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -40,7 +40,6 @@ import (
 	stackitv1alpha1 "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/apis/stackit/v1alpha1"
 	. "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/controller/worker"
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/feature"
-	mockclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/mock/controller-runtime/client"
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/openstack"
 )
 

--- a/pkg/stackit/credentials_test.go
+++ b/pkg/stackit/credentials_test.go
@@ -20,9 +20,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	mockclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/mock/controller-runtime/client"
 	. "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit"
@@ -36,8 +38,7 @@ var (
 var _ = Describe("Secret", func() {
 	Describe("#GetCredentialsFromSecretRef", func() {
 		var (
-			ctrl *gomock.Controller
-			c    *mockclient.MockClient
+			c client.Client
 
 			ctx       = context.TODO()
 			namespace = "namespace"
@@ -50,18 +51,18 @@ var _ = Describe("Secret", func() {
 		)
 
 		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-
-			c = mockclient.NewMockClient(ctrl)
-		})
-
-		AfterEach(func() {
-			ctrl.Finish()
+			c = fake.NewClientBuilder().Build()
 		})
 
 		It("should fail if the secret could not be read", func() {
 			fakeErr := errors.New("error")
-			c.EXPECT().Get(ctx, client.ObjectKey{namespace, name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr)
+			c = fake.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(_ context.Context, _ client.WithWatch, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+					Expect(key).To(Equal(client.ObjectKey{Namespace: namespace, Name: name}))
+					Expect(obj).To(BeAssignableToTypeOf(&corev1.Secret{}))
+					return fakeErr
+				},
+			}).Build()
 
 			credentials, err := GetCredentialsFromSecretRef(ctx, c, secretRef)
 
@@ -70,19 +71,16 @@ var _ = Describe("Secret", func() {
 		})
 
 		It("should return the correct credentials object", func() {
-			c.EXPECT().Get(
-				ctx, client.ObjectKey{namespace, name},
-				gomock.AssignableToTypeOf(&corev1.Secret{}),
-				gomock.Any(),
-			).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
-					secret.Data = map[string][]byte{
-						ProjectID: []byte(projectID),
-						SaKeyJSON: []byte(saKeyJSON),
-					}
-					return nil
+			c = fake.NewClientBuilder().WithObjects(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretRef.Name,
+					Namespace: secretRef.Namespace,
 				},
-			)
+				Data: map[string][]byte{
+					ProjectID: []byte(projectID),
+					SaKeyJSON: []byte(saKeyJSON),
+				},
+			}).Build()
 
 			credentials, err := GetCredentialsFromSecretRef(ctx, c, secretRef)
 

--- a/pkg/stackit/credentials_test.go
+++ b/pkg/stackit/credentials_test.go
@@ -26,7 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
-	mockclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/mock/controller-runtime/client"
 	. "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit"
 )
 


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:
We want to migrate away from the mock client. This PR uses the fake client instead.
We cannot delete the generated mock client yet since the `valuesprovider_test.go` still uses it. This file needs a major rewrite and i want to create a separate PR for that.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
