### PR TITLE
Add CSI/CCM images for kubernetes 1.36; Drop Support for kubernetes 1.32

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -3,11 +3,6 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
-  tag: "v1.32.1"
-  targetVersion: "1.32.x"
-- name: cloud-controller-manager
-  sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
   tag: "v1.33.1"
   targetVersion: "1.33.x"
 - name: cloud-controller-manager
@@ -27,6 +22,11 @@ images:
   targetVersion: ">= 1.36"
 
 
+- name: stackit-cloud-controller-manager
+  sourceRepository: https://github.com/stackitcloud/cloud-provider-stackit
+  repository: ghcr.io/stackitcloud/cloud-provider-stackit/cloud-controller-manager
+  tag: "v1.33.17"
+  targetVersion: "1.33.x"
 - name: stackit-cloud-controller-manager
   sourceRepository: https://github.com/stackitcloud/cloud-provider-stackit
   repository: ghcr.io/stackitcloud/cloud-provider-stackit/cloud-controller-manager
@@ -55,11 +55,6 @@ images:
 - name: csi-driver-cinder
   sourceRepository: github.com/stackitcloud/cloud-provider-openstack
   repository: registry.ske.stackit.cloud/stackitcloud/cinder-csi-plugin
-  tag: "v1.32.4-ske-1"
-  targetVersion: "1.32.x"
-- name: csi-driver-cinder
-  sourceRepository: github.com/stackitcloud/cloud-provider-openstack
-  repository: registry.ske.stackit.cloud/stackitcloud/cinder-csi-plugin
   tag: "v1.33.0-ske-1"
   targetVersion: "1.33.x"
 - name: csi-driver-cinder
@@ -78,6 +73,11 @@ images:
   tag: "v1.36.0-ske-1"
   targetVersion: '>= 1.36'
 
+- name: csi-driver-stackit
+  sourceRepository: github.com/stackitcloud/cloud-provider-stackit
+  repository: ghcr.io/stackitcloud/cloud-provider-stackit/stackit-csi-plugin
+  tag: "v1.33.17"
+  targetVersion: "1.33.x"
 - name: csi-driver-stackit
   sourceRepository: github.com/stackitcloud/cloud-provider-stackit
   repository: ghcr.io/stackitcloud/cloud-provider-stackit/stackit-csi-plugin

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -19,7 +19,12 @@ images:
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
   tag: "v1.35.0"
-  targetVersion: ">= 1.35"
+  targetVersion: "1.35.x"
+- name: cloud-controller-manager
+  sourceRepository: github.com/kubernetes/cloud-provider-openstack
+  repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
+  tag: "v1.36.0"
+  targetVersion: ">= 1.36"
 
 - name: stackit-cloud-controller-manager
   sourceRepository: https://github.com/stackitcloud/cloud-provider-stackit
@@ -40,7 +45,12 @@ images:
   sourceRepository: https://github.com/stackitcloud/cloud-provider-stackit
   repository: ghcr.io/stackitcloud/cloud-provider-stackit/cloud-controller-manager
   tag: "v1.35.4"
-  targetVersion: ">= 1.35"
+  targetVersion: "1.35.x"
+- name: stackit-cloud-controller-manager
+  sourceRepository: https://github.com/stackitcloud/cloud-provider-stackit
+  repository: ghcr.io/stackitcloud/cloud-provider-stackit/cloud-controller-manager
+  tag: "v1.36.2"
+  targetVersion: ">= 1.36"
 
 - name: machine-controller-manager-provider-openstack
   sourceRepository: github.com/gardener/machine-controller-manager-provider-openstack
@@ -67,10 +77,15 @@ images:
   tag: "v1.34.1-ske-1"
   targetVersion: 1.34.x
 - name: csi-driver-cinder
-  sourceRepository: github.com/kubernetes/cloud-provider-openstack
+  sourceRepository: github.com/stackitcloud/cloud-provider-openstack
   repository: registry.ske.stackit.cloud/stackitcloud/cinder-csi-plugin
   tag: "v1.35.0-ske-1"
-  targetVersion: '>= 1.35'
+  targetVersion: '1.35.x'
+- name: csi-driver-cinder
+  sourceRepository: github.com/stackitcloud/cloud-provider-openstack
+  repository: registry.ske.stackit.cloud/stackitcloud/cinder-csi-plugin
+  tag: "v1.36.0-ske-1"
+  targetVersion: '>= 1.36'
 
 - name: csi-driver-stackit
   sourceRepository: github.com/stackitcloud/cloud-provider-stackit
@@ -91,7 +106,12 @@ images:
   sourceRepository: github.com/stackitcloud/cloud-provider-stackit
   repository: ghcr.io/stackitcloud/cloud-provider-stackit/stackit-csi-plugin
   tag: "v1.35.4"
-  targetVersion: ">= 1.35"
+  targetVersion: "1.35.x"
+- name: csi-driver-stackit
+  sourceRepository: github.com/stackitcloud/cloud-provider-stackit
+  repository: ghcr.io/stackitcloud/cloud-provider-stackit/stackit-csi-plugin
+  tag: "v1.36.2"
+  targetVersion: ">= 1.36"
 
 - name: csi-provisioner
   sourceRepository: github.com/kubernetes-csi/external-provisioner

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -26,25 +26,16 @@ images:
   tag: "v1.36.0"
   targetVersion: ">= 1.36"
 
+
 - name: stackit-cloud-controller-manager
   sourceRepository: https://github.com/stackitcloud/cloud-provider-stackit
   repository: ghcr.io/stackitcloud/cloud-provider-stackit/cloud-controller-manager
-  tag: "v1.32.16"
-  targetVersion: "1.32.x"
-- name: stackit-cloud-controller-manager
-  sourceRepository: https://github.com/stackitcloud/cloud-provider-stackit
-  repository: ghcr.io/stackitcloud/cloud-provider-stackit/cloud-controller-manager
-  tag: "v1.33.16"
-  targetVersion: "1.33.x"
-- name: stackit-cloud-controller-manager
-  sourceRepository: https://github.com/stackitcloud/cloud-provider-stackit
-  repository: ghcr.io/stackitcloud/cloud-provider-stackit/cloud-controller-manager
-  tag: "v1.34.9"
+  tag: "v1.34.10"
   targetVersion: "1.34.x"
 - name: stackit-cloud-controller-manager
   sourceRepository: https://github.com/stackitcloud/cloud-provider-stackit
   repository: ghcr.io/stackitcloud/cloud-provider-stackit/cloud-controller-manager
-  tag: "v1.35.4"
+  tag: "v1.35.5"
   targetVersion: "1.35.x"
 - name: stackit-cloud-controller-manager
   sourceRepository: https://github.com/stackitcloud/cloud-provider-stackit
@@ -90,22 +81,12 @@ images:
 - name: csi-driver-stackit
   sourceRepository: github.com/stackitcloud/cloud-provider-stackit
   repository: ghcr.io/stackitcloud/cloud-provider-stackit/stackit-csi-plugin
-  tag: "v1.32.16"
-  targetVersion: "1.32.x"
-- name: csi-driver-stackit
-  sourceRepository: github.com/stackitcloud/cloud-provider-stackit
-  repository: ghcr.io/stackitcloud/cloud-provider-stackit/stackit-csi-plugin
-  tag: "v1.33.16"
-  targetVersion: "1.33.x"
-- name: csi-driver-stackit
-  sourceRepository: github.com/stackitcloud/cloud-provider-stackit
-  repository: ghcr.io/stackitcloud/cloud-provider-stackit/stackit-csi-plugin
-  tag: "v1.34.9"
+  tag: "v1.34.10"
   targetVersion: "1.34.x"
 - name: csi-driver-stackit
   sourceRepository: github.com/stackitcloud/cloud-provider-stackit
   repository: ghcr.io/stackitcloud/cloud-provider-stackit/stackit-csi-plugin
-  tag: "v1.35.4"
+  tag: "v1.35.5"
   targetVersion: "1.35.x"
 - name: csi-driver-stackit
   sourceRepository: github.com/stackitcloud/cloud-provider-stackit


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement

**What this PR does / why we need it**:
This PR:

- Adds CSI/CCM for 1.36
- Drops 1.32
- Bumps STACKIT CSI/CCM for 1.33, 1.34, 1.35

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
