### PR TITLE
Add validation webhook for shoot object in logging mode

### DIFF
--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -70,7 +70,9 @@ func (s *shoot) Validate(_ context.Context, newObj, oldObj client.Object) error 
 	}
 
 	// only log errors for now to be able to check the logs after a while before actually fail validation.
-	logger.Error(allErrs.ToAggregate(), "Shoot would have failed validation", "name", shoot.Name, "namespace", shoot.Namespace)
+	if allErrs.ToAggregate() != nil {
+		logger.Error(allErrs.ToAggregate(), "Shoot would have failed validation", "name", shoot.Name, "namespace", shoot.Namespace)
+	}
 
 	return nil
 }

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validator
+
+import (
+	"context"
+	"fmt"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/core"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/apis/stackit/helper"
+	stackitvalidation "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/apis/stackit/validation"
+)
+
+// NewShootValidator returns a new instance of a shoot validator.
+func NewShootValidator(mgr manager.Manager) extensionswebhook.Validator {
+	return &shoot{}
+}
+
+type shoot struct{}
+
+// Validate validates the given shoot objects.
+func (s *shoot) Validate(_ context.Context, newObj, oldObj client.Object) error {
+	shoot, ok := newObj.(*core.Shoot)
+	if !ok {
+		return fmt.Errorf("wrong object type %T", newObj)
+	}
+
+	if shoot.Spec.Provider.ControlPlaneConfig == nil {
+		return nil
+	}
+
+	cpConfig, err := helper.ControlPlaneConfigFromRawExtension(shoot.Spec.Provider.ControlPlaneConfig)
+	if err != nil {
+		return err
+	}
+
+	infraConfig, err := helper.InfrastructureConfigFromRawExtension(shoot.Spec.Provider.InfrastructureConfig)
+	if err != nil {
+		return err
+	}
+
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, stackitvalidation.ValidateControlPlaneConfig(cpConfig, shoot.Spec.Kubernetes.Version, field.NewPath("spec").Child("providerConfig"))...)
+
+	allErrs = append(allErrs, stackitvalidation.ValidateInfrastructureConfig(infraConfig, shoot.Spec.Networking.Nodes, field.NewPath("spec").Child("providerConfig").Child("infrastructureConfig"))...)
+
+	if oldObj != nil {
+		oldShoot, ok := oldObj.(*core.Shoot)
+		if !ok {
+			return fmt.Errorf("wrong object type %T for old object", oldObj)
+		}
+		oldInfraConfig, err := helper.InfrastructureConfigFromRawExtension(oldShoot.Spec.Provider.InfrastructureConfig)
+		if err != nil {
+			return err
+		}
+		allErrs = append(allErrs, stackitvalidation.ValidateInfrastructureConfigUpdate(oldInfraConfig, infraConfig, field.NewPath("spec").Child("providerConfig").Child("infrastructureConfig"))...)
+	}
+
+	return allErrs.ToAggregate()
+}

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -69,5 +69,8 @@ func (s *shoot) Validate(_ context.Context, newObj, oldObj client.Object) error 
 		allErrs = append(allErrs, stackitvalidation.ValidateControlPlaneConfigUpdate(oldCpConfig, cpConfig, field.NewPath("spec").Child("provider").Child("controlPlaneConfig"))...)
 	}
 
-	return allErrs.ToAggregate()
+	// only log errors for now to be able to check the logs after a while before actually fail validation.
+	logger.Error(allErrs.ToAggregate(), "Shoot would have failed validation", "name", shoot.Name, "namespace", shoot.Namespace)
+
+	return nil
 }

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -11,6 +11,7 @@ import (
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -32,10 +33,6 @@ func (s *shoot) Validate(_ context.Context, newObj, oldObj client.Object) error 
 		return fmt.Errorf("wrong object type %T", newObj)
 	}
 
-	if shoot.Spec.Provider.ControlPlaneConfig == nil {
-		return nil
-	}
-
 	cpConfig, err := helper.ControlPlaneConfigFromRawExtension(shoot.Spec.Provider.ControlPlaneConfig)
 	if err != nil {
 		return err
@@ -50,18 +47,26 @@ func (s *shoot) Validate(_ context.Context, newObj, oldObj client.Object) error 
 
 	allErrs = append(allErrs, stackitvalidation.ValidateControlPlaneConfig(cpConfig, shoot.Spec.Kubernetes.Version, field.NewPath("spec").Child("provider").Child("controlPlaneConfig"))...)
 
-	allErrs = append(allErrs, stackitvalidation.ValidateInfrastructureConfig(infraConfig, shoot.Spec.Networking.Nodes, field.NewPath("spec").Child("provider").Child("infrastructureConfig"))...)
+	allErrs = append(allErrs, stackitvalidation.ValidateInfrastructureConfig(infraConfig, ptr.Deref(shoot.Spec.Networking, core.Networking{}).Nodes, field.NewPath("spec").Child("provider").Child("infrastructureConfig"))...)
 
 	if oldObj != nil {
 		oldShoot, ok := oldObj.(*core.Shoot)
 		if !ok {
 			return fmt.Errorf("wrong object type %T for old object", oldObj)
 		}
+
 		oldInfraConfig, err := helper.InfrastructureConfigFromRawExtension(oldShoot.Spec.Provider.InfrastructureConfig)
 		if err != nil {
 			return err
 		}
+
+		oldCpConfig, err := helper.ControlPlaneConfigFromRawExtension(oldShoot.Spec.Provider.ControlPlaneConfig)
+		if err != nil {
+			return err
+		}
+
 		allErrs = append(allErrs, stackitvalidation.ValidateInfrastructureConfigUpdate(oldInfraConfig, infraConfig, field.NewPath("spec").Child("provider").Child("infrastructureConfig"))...)
+		allErrs = append(allErrs, stackitvalidation.ValidateControlPlaneConfigUpdate(oldCpConfig, cpConfig, field.NewPath("spec").Child("provider").Child("controlPlaneConfig"))...)
 	}
 
 	return allErrs.ToAggregate()

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -48,9 +48,9 @@ func (s *shoot) Validate(_ context.Context, newObj, oldObj client.Object) error 
 
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, stackitvalidation.ValidateControlPlaneConfig(cpConfig, shoot.Spec.Kubernetes.Version, field.NewPath("spec").Child("providerConfig"))...)
+	allErrs = append(allErrs, stackitvalidation.ValidateControlPlaneConfig(cpConfig, shoot.Spec.Kubernetes.Version, field.NewPath("spec").Child("provider").Child("controlPlaneConfig"))...)
 
-	allErrs = append(allErrs, stackitvalidation.ValidateInfrastructureConfig(infraConfig, shoot.Spec.Networking.Nodes, field.NewPath("spec").Child("providerConfig").Child("infrastructureConfig"))...)
+	allErrs = append(allErrs, stackitvalidation.ValidateInfrastructureConfig(infraConfig, shoot.Spec.Networking.Nodes, field.NewPath("spec").Child("provider").Child("infrastructureConfig"))...)
 
 	if oldObj != nil {
 		oldShoot, ok := oldObj.(*core.Shoot)
@@ -61,7 +61,7 @@ func (s *shoot) Validate(_ context.Context, newObj, oldObj client.Object) error 
 		if err != nil {
 			return err
 		}
-		allErrs = append(allErrs, stackitvalidation.ValidateInfrastructureConfigUpdate(oldInfraConfig, infraConfig, field.NewPath("spec").Child("providerConfig").Child("infrastructureConfig"))...)
+		allErrs = append(allErrs, stackitvalidation.ValidateInfrastructureConfigUpdate(oldInfraConfig, infraConfig, field.NewPath("spec").Child("provider").Child("infrastructureConfig"))...)
 	}
 
 	return allErrs.ToAggregate()

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validator_test
+
+import (
+	"context"
+	"encoding/json"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/utils/test"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/admission/validator"
+	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/apis/stackit/install"
+	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/apis/stackit/v1alpha1"
+	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit"
+)
+
+var _ = Describe("NamespacedCloudProfile Validator", func() {
+	var (
+		fakeClient  client.Client
+		fakeManager manager.Manager
+		ctx         = context.Background()
+
+		shootValidator extensionswebhook.Validator
+		shoot          *core.Shoot
+
+		infrastructureConfig v1alpha1.InfrastructureConfig
+	)
+
+	BeforeEach(func() {
+		scheme := runtime.NewScheme()
+		utilruntime.Must(install.AddToScheme(scheme))
+		utilruntime.Must(v1beta1.AddToScheme(scheme))
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+		fakeManager = &test.FakeManager{
+			Client: fakeClient,
+			Scheme: scheme,
+		}
+		shootValidator = validator.NewShootValidator(fakeManager)
+
+		infrastructureConfig = v1alpha1.InfrastructureConfig{
+			FloatingPoolName: "floating-pool",
+			Networks: v1alpha1.Networks{
+				Workers: "10.0.0.0/24",
+			},
+		}
+
+		shoot = &core.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "shoot",
+			},
+			Spec: core.ShootSpec{
+				Provider: core.Provider{
+					Type: stackit.Type,
+					InfrastructureConfig: &runtime.RawExtension{
+						Raw: encode(&infrastructureConfig),
+					},
+				},
+				Networking: &core.Networking{Nodes: new("10.0.0.0/24")},
+			},
+		}
+	})
+
+	Describe("#Validate", func() {
+		It("should succeed for shoot with minimal config", func() {
+			Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
+		})
+		It("should succeed for shoot with networkID instead of worker CIDR", func() {
+			infrastructureConfig.Networks.Workers = ""
+			infrastructureConfig.Networks.ID = new(uuid.NewString())
+			shoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{Raw: encode(&infrastructureConfig)}
+
+			Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
+		})
+		It("should succeed when spec.networking is nil", func() {
+			shoot.Spec.Networking = nil
+
+			Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
+		})
+		It("should fail for without worker cird and networkID", func() {
+			infrastructureConfig.Networks.Workers = ""
+			shoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{Raw: encode(&infrastructureConfig)}
+
+			Expect(shootValidator.Validate(ctx, shoot, nil)).To(Not(Succeed()))
+		})
+		It("should fail for with invalid ControlPlaneConfig", func() {
+			shoot.Spec.Provider.ControlPlaneConfig = &runtime.RawExtension{Raw: []byte(`{"foo": "bar"}`)}
+
+			Expect(shootValidator.Validate(ctx, shoot, nil)).To(Not(Succeed()))
+		})
+		It("should fail for with invalid InfrastructureConfig", func() {
+			shoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{Raw: []byte(`{"foo": "bar"}`)}
+
+			Expect(shootValidator.Validate(ctx, shoot, nil)).To(Not(Succeed()))
+		})
+		It("should fail for with invalid invalid CSI driver", func() {
+			controlPlaneConfig := v1alpha1.ControlPlaneConfig{
+				Storage: &v1alpha1.Storage{
+					CSI: &v1alpha1.CSI{
+						Name: "foobar",
+					},
+				},
+			}
+
+			shoot.Spec.Provider.ControlPlaneConfig = &runtime.RawExtension{Raw: encode(&controlPlaneConfig)}
+
+			Expect(shootValidator.Validate(ctx, shoot, nil)).To(Not(Succeed()))
+		})
+
+		It("should fail for immutable field", func() {
+			infrastructureConfig.Networks.Workers = "10.0.1.0/24"
+			newShoot := shoot.DeepCopy()
+			newShoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{Raw: encode(&infrastructureConfig)}
+
+			Expect(shootValidator.Validate(ctx, newShoot, shoot)).To(Not(Succeed()))
+		})
+	})
+})
+
+func encode(object runtime.Object) []byte {
+	GinkgoHelper()
+	data, err := json.Marshal(object)
+	Expect(err).NotTo(HaveOccurred())
+	return data
+}

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -94,7 +94,8 @@ var _ = Describe("NamespacedCloudProfile Validator", func() {
 			infrastructureConfig.Networks.Workers = ""
 			shoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{Raw: encode(&infrastructureConfig)}
 
-			Expect(shootValidator.Validate(ctx, shoot, nil)).To(Not(Succeed()))
+			// Enable test after validation is not in log only mode
+			// Expect(shootValidator.Validate(ctx, shoot, nil)).To(Not(Succeed()))
 		})
 		It("should fail for with invalid ControlPlaneConfig", func() {
 			shoot.Spec.Provider.ControlPlaneConfig = &runtime.RawExtension{Raw: []byte(`{"foo": "bar"}`)}
@@ -117,7 +118,8 @@ var _ = Describe("NamespacedCloudProfile Validator", func() {
 
 			shoot.Spec.Provider.ControlPlaneConfig = &runtime.RawExtension{Raw: encode(&controlPlaneConfig)}
 
-			Expect(shootValidator.Validate(ctx, shoot, nil)).To(Not(Succeed()))
+			// Enable test after validation is not in log only mode
+			// Expect(shootValidator.Validate(ctx, shoot, nil)).To(Not(Succeed()))
 		})
 
 		It("should fail for immutable field", func() {
@@ -125,7 +127,8 @@ var _ = Describe("NamespacedCloudProfile Validator", func() {
 			newShoot := shoot.DeepCopy()
 			newShoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{Raw: encode(&infrastructureConfig)}
 
-			Expect(shootValidator.Validate(ctx, newShoot, shoot)).To(Not(Succeed()))
+			// Enable test after validation is not in log only mode
+			// Expect(shootValidator.Validate(ctx, newShoot, shoot)).To(Not(Succeed()))
 		})
 	})
 })

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -26,6 +26,7 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		Path: "/webhooks/validate",
 		Validators: map[extensionswebhook.Validator][]extensionswebhook.Type{
 			NewCloudProfileValidator(mgr):           {{Obj: &core.CloudProfile{}}},
+			NewShootValidator(mgr):                  {{Obj: &core.Shoot{}}},
 			NewNamespacedCloudProfileValidator(mgr): {{Obj: &core.NamespacedCloudProfile{}}},
 		},
 		Target: extensionswebhook.TargetSeed,

--- a/pkg/apis/stackit/helper/scheme.go
+++ b/pkg/apis/stackit/helper/scheme.go
@@ -86,6 +86,16 @@ func CloudProfileConfigFromCluster(cluster *controller.Cluster) (*stackitv1alpha
 	return cloudProfileConfig, nil
 }
 
+func ControlPlaneConfigFromRawExtension(raw *runtime.RawExtension) (*stackitv1alpha1.ControlPlaneConfig, error) {
+	cpConfig := &stackitv1alpha1.ControlPlaneConfig{}
+	setGVK(cpConfig)
+
+	if err := decode(raw, cpConfig); err != nil {
+		return nil, err
+	}
+	return cpConfig, nil
+}
+
 func CloudProfileConfigFromRawExtension(raw *runtime.RawExtension) (*stackitv1alpha1.CloudProfileConfig, error) {
 	cpConfig := &stackitv1alpha1.CloudProfileConfig{}
 	setGVK(cpConfig)

--- a/pkg/apis/stackit/validation/controlplane.go
+++ b/pkg/apis/stackit/validation/controlplane.go
@@ -21,13 +21,10 @@ var (
 )
 
 // ValidateControlPlaneConfig validates a ControlPlaneConfig object.
-func ValidateControlPlaneConfig(controlPlaneConfig *stackitv1alpha1.ControlPlaneConfig, infraConfig *stackitv1alpha1.InfrastructureConfig, version string, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+func ValidateControlPlaneConfig(controlPlaneConfig *stackitv1alpha1.ControlPlaneConfig, version string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{} // nolint:prealloc // size is not known yet
 
-	if controlPlaneConfig.CloudControllerManager != nil {
-		allErrs = append(allErrs, featurevalidation.ValidateFeatureGates(controlPlaneConfig.CloudControllerManager.FeatureGates, version, fldPath.Child("cloudControllerManager", "featureGates"))...)
-		allErrs = append(allErrs, validateCloudController(controlPlaneConfig.CloudControllerManager, fldPath.Child("cloudControllerManager"))...)
-	}
+	allErrs = append(allErrs, validateCloudController(controlPlaneConfig.CloudControllerManager, version, fldPath.Child("cloudControllerManager"))...)
 
 	allErrs = append(allErrs, validateStorage(controlPlaneConfig.Storage, fldPath.Child("storage"))...)
 
@@ -48,7 +45,7 @@ func ValidateControlPlaneConfigAgainstCloudProfile(oldCpConfig, cpConfig *stacki
 	return allErrs
 }
 
-func validateCloudController(cloudcontroller *stackitv1alpha1.CloudControllerManagerConfig, fldPath *field.Path) field.ErrorList {
+func validateCloudController(cloudcontroller *stackitv1alpha1.CloudControllerManagerConfig, version string, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	if cloudcontroller == nil {
 		return allErrs
@@ -56,6 +53,8 @@ func validateCloudController(cloudcontroller *stackitv1alpha1.CloudControllerMan
 	if cloudcontroller.Name != "" && !slices.Contains(validControllers, stackitv1alpha1.ControllerName(cloudcontroller.Name)) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), cloudcontroller.Name, "not supported ccm driver"))
 	}
+	allErrs = append(allErrs, featurevalidation.ValidateFeatureGates(cloudcontroller.FeatureGates, version, fldPath.Child("featureGates"))...)
+
 	return allErrs
 }
 

--- a/pkg/apis/stackit/validation/controlplane_test.go
+++ b/pkg/apis/stackit/validation/controlplane_test.go
@@ -18,17 +18,15 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 	var (
 		nilPath      *field.Path
 		controlPlane *stackitv1alpha1.ControlPlaneConfig
-		infraConfig  *stackitv1alpha1.InfrastructureConfig
 	)
 
 	BeforeEach(func() {
 		controlPlane = &stackitv1alpha1.ControlPlaneConfig{}
-		infraConfig = &stackitv1alpha1.InfrastructureConfig{}
 	})
 
 	Describe("#ValidateControlPlaneConfig", func() {
 		It("should return no errors for a valid configuration", func() {
-			Expect(ValidateControlPlaneConfig(controlPlane, infraConfig, "", nilPath)).To(BeEmpty())
+			Expect(ValidateControlPlaneConfig(controlPlane, "", nilPath)).To(BeEmpty())
 		})
 
 		It("should fail with invalid CCM feature gates", func() {
@@ -39,7 +37,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 				},
 			}
 
-			errorList := ValidateControlPlaneConfig(controlPlane, infraConfig, "1.28.2", nilPath)
+			errorList := ValidateControlPlaneConfig(controlPlane, "1.28.2", nilPath)
 
 			Expect(errorList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
@@ -53,7 +51,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 			controlPlane.Storage = &stackitv1alpha1.Storage{
 				CSI: &stackitv1alpha1.CSI{Name: "stackit", CompatibilityMode: "bogus"},
 			}
-			Expect(ValidateControlPlaneConfig(controlPlane, infraConfig, "", nilPath)).To(ConsistOf(
+			Expect(ValidateControlPlaneConfig(controlPlane, "", nilPath)).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
 					"Field": Equal("storage.csi.compatibilityMode"),

--- a/pkg/apis/stackit/validation/infrastructure.go
+++ b/pkg/apis/stackit/validation/infrastructure.go
@@ -61,7 +61,7 @@ func ValidateInfrastructureConfig(infra *stackitv1alpha1.InfrastructureConfig, n
 		}
 	}
 
-	// eather InfrastructureConfig.networks.id or InfrastructureConfig.networks.worker(s) has to be set
+	// either InfrastructureConfig.networks.id or InfrastructureConfig.networks.worker(s) has to be set
 	if workerCIDR == nil && infra.Networks.ID == nil {
 		allErrs = append(allErrs, field.Required(networksPath.Child("workers"), "must specify the network range for the worker network or provide a network ID for the network"))
 	}

--- a/pkg/apis/stackit/validation/infrastructure.go
+++ b/pkg/apis/stackit/validation/infrastructure.go
@@ -23,18 +23,9 @@ func ValidateInfrastructureConfig(infra *stackitv1alpha1.InfrastructureConfig, n
 		allErrs = append(allErrs, field.Required(fldPath.Child("floatingPoolName"), "must provide the name of a floating pool"))
 	}
 
-	networkingPath := field.NewPath("networking")
-	var nodes cidrvalidation.CIDR
-	if nodesCIDR != nil {
-		nodes = cidrvalidation.NewCIDR(*nodesCIDR, networkingPath.Child("nodes"))
-	}
-
 	networksPath := fldPath.Child("networks")
-	//nolint:staticcheck // SA1019: needed for migration purposes
-	if len(infra.Networks.Worker) == 0 && len(infra.Networks.Workers) == 0 {
-		allErrs = append(allErrs, field.Required(networksPath.Child("workers"), "must specify the network range for the worker network"))
-	}
 
+	// check InfrastructureConfig.networks.worker(s) is a valid cidr and not be set if a network id is provided.
 	var workerCIDR cidrvalidation.CIDR
 	//nolint:staticcheck // SA1019: needed for migration purposes
 	if infra.Networks.Worker != "" {
@@ -43,21 +34,36 @@ func ValidateInfrastructureConfig(infra *stackitv1alpha1.InfrastructureConfig, n
 		allErrs = append(allErrs, cidrvalidation.ValidateCIDRParse(workerCIDR)...)
 		//nolint:staticcheck // SA1019: needed for migration purposes
 		allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(networksPath.Child("worker"), infra.Networks.Worker)...)
+		if infra.Networks.ID != nil {
+			allErrs = append(allErrs, field.Forbidden(networksPath.Child("worker"), "cant be set if a network id is provided"))
+		}
 	}
 	if infra.Networks.Workers != "" {
 		workerCIDR = cidrvalidation.NewCIDR(infra.Networks.Workers, networksPath.Child("workers"))
 		allErrs = append(allErrs, cidrvalidation.ValidateCIDRParse(workerCIDR)...)
 		allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(networksPath.Child("workers"), infra.Networks.Workers)...)
+		if infra.Networks.ID != nil {
+			allErrs = append(allErrs, field.Forbidden(networksPath.Child("workers"), "cant be set if a network id is provided"))
+		}
 	}
 
-	if nodes != nil {
+	// check if InfrastructureConfig.networks.worker(s) is a subset of spec.networking.nodes
+	var nodes cidrvalidation.CIDR
+	if nodesCIDR != nil {
+		nodes = cidrvalidation.NewCIDR(*nodesCIDR, field.NewPath("spec").Child("networking").Child("nodes"))
 		allErrs = append(allErrs, nodes.ValidateSubset(workerCIDR)...)
 	}
 
+	// validate that InfrastructureConfig.networks.id is a valid uuid
 	if infra.Networks.ID != nil {
 		if _, err := uuid.Parse(*infra.Networks.ID); err != nil {
-			allErrs = append(allErrs, field.Invalid(networksPath.Child("id"), infra.Networks.ID, "if network ID is provided it must be a valid OpenStack UUID"))
+			allErrs = append(allErrs, field.Invalid(networksPath.Child("id"), infra.Networks.ID, "if network ID is provided it must be a valid STACKIT Network ID"))
 		}
+	}
+
+	// eather InfrastructureConfig.networks.id or InfrastructureConfig.networks.worker(s) has to be set
+	if workerCIDR == nil && infra.Networks.ID == nil {
+		allErrs = append(allErrs, field.Required(networksPath.Child("workers"), "must specify the network range for the worker network or provide a network ID for the network"))
 	}
 
 	if infra.Networks.SubnetID != nil {

--- a/pkg/apis/stackit/validation/infrastructure_test.go
+++ b/pkg/apis/stackit/validation/infrastructure_test.go
@@ -32,9 +32,6 @@ var _ = Describe("InfrastructureConfig validation", func() {
 		infrastructureConfig = &stackitv1alpha1.InfrastructureConfig{
 			FloatingPoolName: floatingPoolName1,
 			Networks: stackitv1alpha1.Networks{
-				Router: &stackitv1alpha1.Router{
-					ID: "hugo",
-				},
 				Workers: "10.250.0.0/16",
 			},
 		}
@@ -88,6 +85,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 		})
 
 		It("should forbid an invalid subnet id", func() {
+			infrastructureConfig.Networks.Workers = ""
 			infrastructureConfig.Networks.ID = new(uuid.NewString())
 			infrastructureConfig.Networks.SubnetID = new("thisiswrong")
 
@@ -101,6 +99,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 		})
 
 		It("should allow an valid OpenStack UUID as subnet ID", func() {
+			infrastructureConfig.Networks.Workers = ""
 			infrastructureConfig.Networks.ID = new(uuid.NewString())
 			infrastructureConfig.Networks.SubnetID = new(uuid.NewString())
 
@@ -111,7 +110,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 	})
 
 	Context("CIDR", func() {
-		It("should forbid empty workers CIDR", func() {
+		It("should forbid empty workers CIDR and no network id", func() {
 			infrastructureConfig.Networks.Workers = ""
 
 			errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, nilPath)
@@ -119,7 +118,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			Expect(errorList).To(ConsistOfFields(Fields{
 				"Type":   Equal(field.ErrorTypeRequired),
 				"Field":  Equal("networks.workers"),
-				"Detail": Equal("must specify the network range for the worker network"),
+				"Detail": Equal("must specify the network range for the worker network or provide a network ID for the network"),
 			}))
 		})
 
@@ -143,7 +142,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			Expect(errorList).To(ConsistOfFields(Fields{
 				"Type":   Equal(field.ErrorTypeInvalid),
 				"Field":  Equal("networks.workers"),
-				"Detail": Equal(`must be a subset of "networking.nodes" ("10.250.0.0/16")`),
+				"Detail": Equal(`must be a subset of "spec.networking.nodes" ("10.250.0.0/16")`),
 			}))
 		})
 
@@ -163,6 +162,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 		})
 
 		It("should forbid an invalid network id configuration", func() {
+			infrastructureConfig.Networks.Workers = ""
 			invalidID := "thisiswrong"
 			infrastructureConfig.Networks.ID = &invalidID
 
@@ -174,7 +174,21 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			}))
 		})
 
-		It("should allow an valid OpenStack UUID as network ID", func() {
+		It("should forbid an valid UUID as network ID when workers is also set", func() {
+			id, err := uuid.NewUUID()
+			Expect(err).NotTo(HaveOccurred())
+			infrastructureConfig.Networks.ID = new(id.String())
+
+			errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, nilPath)
+
+			Expect(errorList).To(ConsistOfFields(Fields{
+				"Type":  Equal(field.ErrorTypeForbidden),
+				"Field": Equal("networks.workers"),
+			}))
+		})
+
+		It("should allow empty workers CIDR and when valid network id is set", func() {
+			infrastructureConfig.Networks.Workers = ""
 			id, err := uuid.NewUUID()
 			Expect(err).NotTo(HaveOccurred())
 			infrastructureConfig.Networks.ID = new(id.String())


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement
/cc @stackitcloud/ske-infrastructure 

**What this PR does / why we need it**:

We already have validation functions for the `ControlPlaneConfig` and `InfrastructureConfig` but we had no validation webhook for the shoot object. This PR adds the webhook.

It also fixes the `InfrastructureConfig` as this was not working, as it is possible to habe no `InfrastructureConfig.Networks.Workers` if `InfrastructureConfig.Networks.ID` is set. 

I created a cluster with and without SNA via the ske-api.

We want to use this for the ALB integration #54 


**Special notes for your reviewer**:

Please also check the validation itself as this was not used before and needed already adoption in the `InfrastructureConfig` part.


