### PR TITLE
Add stricter validation for CSI compatibility mode

### DIFF
--- a/pkg/apis/stackit/validation/controlplane.go
+++ b/pkg/apis/stackit/validation/controlplane.go
@@ -67,13 +67,22 @@ func validateStorage(storage *stackitv1alpha1.Storage, fldPath *field.Path) fiel
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("csi", "name"), storage.CSI.Name, "not supported csi driver"))
 	}
 	// CompatibilityMode is optional; empty is accepted (defaulting sets it to "default").
-	if storage.CSI.CompatibilityMode != "" &&
-		!slices.Contains(validCSICompatibilityModes, stackitv1alpha1.CSICompatibilityMode(storage.CSI.CompatibilityMode)) {
-		allErrs = append(allErrs, field.Invalid(
-			fldPath.Child("csi", "compatibilityMode"),
-			storage.CSI.CompatibilityMode,
-			"not supported CSI compatibility mode",
-		))
+	if storage.CSI.CompatibilityMode != "" {
+		if !slices.Contains(validCSICompatibilityModes, stackitv1alpha1.CSICompatibilityMode(storage.CSI.CompatibilityMode)) {
+			allErrs = append(allErrs, field.Invalid(
+				fldPath.Child("csi", "compatibilityMode"),
+				storage.CSI.CompatibilityMode,
+				"not supported CSI compatibility mode",
+			))
+		}
+		if stackitv1alpha1.CSICompatibilityMode(storage.CSI.CompatibilityMode) != stackitv1alpha1.DEFAULT &&
+			stackitv1alpha1.ControllerName(storage.CSI.Name) != stackitv1alpha1.STACKIT {
+			allErrs = append(allErrs, field.Invalid(
+				fldPath.Child("csi", "compatibilityMode"),
+				storage.CSI.CompatibilityMode,
+				"can only be set when CSI driver stackit is in use",
+			))
+		}
 	}
 	return allErrs
 }

--- a/pkg/apis/stackit/validation/controlplane_test.go
+++ b/pkg/apis/stackit/validation/controlplane_test.go
@@ -47,9 +47,44 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 			))
 		})
 
+		It("should succeed with stackit CCM", func() {
+			controlPlane.CloudControllerManager = &stackitv1alpha1.CloudControllerManagerConfig{
+				Name: string(stackitv1alpha1.STACKIT),
+			}
+			Expect(ValidateControlPlaneConfig(controlPlane, "", nilPath).ToAggregate()).To(Succeed())
+		})
+
+		It("should succeed with openstack CCM", func() {
+			controlPlane.CloudControllerManager = &stackitv1alpha1.CloudControllerManagerConfig{
+				Name: string(stackitv1alpha1.OPENSTACK),
+			}
+			Expect(ValidateControlPlaneConfig(controlPlane, "", nilPath).ToAggregate()).To(Succeed())
+		})
+
+		It("should succeed with stackit CSI driver", func() {
+			controlPlane.Storage = &stackitv1alpha1.Storage{
+				CSI: &stackitv1alpha1.CSI{Name: string(stackitv1alpha1.STACKIT)},
+			}
+			Expect(ValidateControlPlaneConfig(controlPlane, "", nilPath).ToAggregate()).To(Succeed())
+		})
+
+		It("should succeed with openstack CSI driver", func() {
+			controlPlane.Storage = &stackitv1alpha1.Storage{
+				CSI: &stackitv1alpha1.CSI{Name: string(stackitv1alpha1.OPENSTACK)},
+			}
+			Expect(ValidateControlPlaneConfig(controlPlane, "", nilPath).ToAggregate()).To(Succeed())
+		})
+
+		It("should succeed with supported CSI compatibility mode", func() {
+			controlPlane.Storage = &stackitv1alpha1.Storage{
+				CSI: &stackitv1alpha1.CSI{Name: string(stackitv1alpha1.STACKIT), CompatibilityMode: string(stackitv1alpha1.COMPAT)},
+			}
+			Expect(ValidateControlPlaneConfig(controlPlane, "", nilPath).ToAggregate()).To(Succeed())
+		})
+
 		It("should fail with an unsupported CSI compatibility mode", func() {
 			controlPlane.Storage = &stackitv1alpha1.Storage{
-				CSI: &stackitv1alpha1.CSI{Name: "stackit", CompatibilityMode: "bogus"},
+				CSI: &stackitv1alpha1.CSI{Name: string(stackitv1alpha1.STACKIT), CompatibilityMode: "bogus"},
 			}
 			Expect(ValidateControlPlaneConfig(controlPlane, "", nilPath)).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
@@ -58,6 +93,43 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 				})),
 			))
 		})
+
+		It("should fail with an CSI compatibility mode and openstack CSI", func() {
+			controlPlane.Storage = &stackitv1alpha1.Storage{
+				CSI: &stackitv1alpha1.CSI{Name: string(stackitv1alpha1.OPENSTACK), CompatibilityMode: string(stackitv1alpha1.COMPAT)},
+			}
+			Expect(ValidateControlPlaneConfig(controlPlane, "", nilPath)).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("storage.csi.compatibilityMode"),
+				})),
+			))
+		})
+
+		It("should fail with an unsupported CSI driver", func() {
+			controlPlane.Storage = &stackitv1alpha1.Storage{
+				CSI: &stackitv1alpha1.CSI{Name: "foobar"},
+			}
+			Expect(ValidateControlPlaneConfig(controlPlane, "", nilPath)).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("storage.csi.name"),
+				})),
+			))
+		})
+
+		It("should fail with an unsupported ccm", func() {
+			controlPlane.CloudControllerManager = &stackitv1alpha1.CloudControllerManagerConfig{
+				Name: "foobar",
+			}
+			Expect(ValidateControlPlaneConfig(controlPlane, "", nilPath)).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("cloudControllerManager.name"),
+				})),
+			))
+		})
+
 	})
 
 	Describe("#ValidateControlPlaneConfigUpdate", func() {


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement
/cc @stackitcloud/ske-infrastructure 
/cc @ftl 

**What this PR does / why we need it**:

This PR adds more validation for `storage.CSI.CompatibilityMode`, so it only can be set to non default if CSI stackit is used.

Additionally this PR adds more tests for the rest of the validations.

