### PR TITLE
Enable shoot validation in addmission webhook

### DIFF
--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -68,6 +68,6 @@ func (s *shoot) Validate(_ context.Context, newObj, oldObj client.Object) error 
 		allErrs = append(allErrs, stackitvalidation.ValidateInfrastructureConfigUpdate(oldInfraConfig, infraConfig, field.NewPath("spec").Child("provider").Child("infrastructureConfig"))...)
 		allErrs = append(allErrs, stackitvalidation.ValidateControlPlaneConfigUpdate(oldCpConfig, cpConfig, field.NewPath("spec").Child("provider").Child("controlPlaneConfig"))...)
 	}
-	
+
 	return allErrs.ToAggregate()
 }

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -68,11 +68,6 @@ func (s *shoot) Validate(_ context.Context, newObj, oldObj client.Object) error 
 		allErrs = append(allErrs, stackitvalidation.ValidateInfrastructureConfigUpdate(oldInfraConfig, infraConfig, field.NewPath("spec").Child("provider").Child("infrastructureConfig"))...)
 		allErrs = append(allErrs, stackitvalidation.ValidateControlPlaneConfigUpdate(oldCpConfig, cpConfig, field.NewPath("spec").Child("provider").Child("controlPlaneConfig"))...)
 	}
-
-	// only log errors for now to be able to check the logs after a while before actually fail validation.
-	if allErrs.ToAggregate() != nil {
-		logger.Error(allErrs.ToAggregate(), "Shoot would have failed validation", "name", shoot.Name, "namespace", shoot.Namespace)
-	}
-
-	return nil
+	
+	return allErrs.ToAggregate()
 }

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -94,8 +94,7 @@ var _ = Describe("NamespacedCloudProfile Validator", func() {
 			infrastructureConfig.Networks.Workers = ""
 			shoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{Raw: encode(&infrastructureConfig)}
 
-			// Enable test after validation is not in log only mode
-			// Expect(shootValidator.Validate(ctx, shoot, nil)).To(Not(Succeed()))
+			Expect(shootValidator.Validate(ctx, shoot, nil)).To(Not(Succeed()))
 		})
 		It("should fail for with invalid ControlPlaneConfig", func() {
 			shoot.Spec.Provider.ControlPlaneConfig = &runtime.RawExtension{Raw: []byte(`{"foo": "bar"}`)}
@@ -118,8 +117,7 @@ var _ = Describe("NamespacedCloudProfile Validator", func() {
 
 			shoot.Spec.Provider.ControlPlaneConfig = &runtime.RawExtension{Raw: encode(&controlPlaneConfig)}
 
-			// Enable test after validation is not in log only mode
-			// Expect(shootValidator.Validate(ctx, shoot, nil)).To(Not(Succeed()))
+			Expect(shootValidator.Validate(ctx, shoot, nil)).To(Not(Succeed()))
 		})
 
 		It("should fail for immutable field", func() {
@@ -127,8 +125,7 @@ var _ = Describe("NamespacedCloudProfile Validator", func() {
 			newShoot := shoot.DeepCopy()
 			newShoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{Raw: encode(&infrastructureConfig)}
 
-			// Enable test after validation is not in log only mode
-			// Expect(shootValidator.Validate(ctx, newShoot, shoot)).To(Not(Succeed()))
+			Expect(shootValidator.Validate(ctx, newShoot, shoot)).To(Not(Succeed()))
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement


**What this PR does / why we need it**:

With PR #203 we added the shoot object to the validation webhook in logging mode but did not fail the validation. This PR enables the actual validation.


