### PR TITLE
Add  `github.com/gardener/gardener/hack/tools` to  `gardener/gardener ` in renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -63,6 +63,7 @@
       matchPackageNames: [
         'github.com/gardener/gardener',
         'github.com/gardener/gardener/pkg/apis',
+        'github.com/gardener/gardener/hack/tools',
       ],
     },
     {


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement
/cc @stackitcloud/ske-infrastructure 
/cc @breuerfelix 

**What this PR does / why we need it**:

With gardener v1.147 (PR #198) there is a new dependency `github.com/gardener/gardener/hack/tools` which this PR adds to the renovate group.

This avoids extra PRs like this #224

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
