### PR TITLE
add CRDs for compatibility mode tests to the upstream-crds make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,9 +145,12 @@ cleanup-crds:
 
 .PHONY: gardener-crds
 gardener-crds:
+	@cp $(GARDENER_DIR)/example/seed-crds/10-crd-autoscaling.k8s.io_verticalpodautoscalers.yaml $(UPSTREAM_CRDS_DIR)
 	@cp $(GARDENER_DIR)/example/seed-crds/10-crd-extensions.gardener.cloud_clusters.yaml $(UPSTREAM_CRDS_DIR)
+	@cp $(GARDENER_DIR)/example/seed-crds/10-crd-extensions.gardener.cloud_controlplanes.yaml $(UPSTREAM_CRDS_DIR)
 	@cp $(GARDENER_DIR)/example/seed-crds/10-crd-extensions.gardener.cloud_infrastructures.yaml $(UPSTREAM_CRDS_DIR)
 	@cp $(GARDENER_DIR)/example/seed-crds/10-crd-extensions.gardener.cloud_selfhostedshootexposures.yaml $(UPSTREAM_CRDS_DIR)
+	@cp $(GARDENER_DIR)/example/resource-manager/10-crd-resources.gardener.cloud_managedresources.yaml $(UPSTREAM_CRDS_DIR)
 
 .PHONY: test
 test: $(REPORT_COLLECTOR) $(SETUP_ENVTEST) ## Runs the unit-test suite

--- a/test/integration/testdata/upstream-crds/10-crd-autoscaling.k8s.io_verticalpodautoscalers.yaml
+++ b/test/integration/testdata/upstream-crds/10-crd-autoscaling.k8s.io_verticalpodautoscalers.yaml
@@ -1,10 +1,12 @@
 ---
+# Important:
+# This file is copied from https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler-1.7.0/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/crds/vpa-v1-crd-gen.yaml#L222-L1006
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes/kubernetes/pull/63797
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: verticalpodautoscalers.autoscaling.k8s.io
 spec:
   group: autoscaling.k8s.io
@@ -33,6 +35,14 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .spec.updatePolicy.minReplicas
+      name: MinReplicas
+      priority: 1
+      type: integer
+    - jsonPath: .spec.updatePolicy.evictAfterOOMSeconds
+      name: OOMSeconds
+      priority: 1
+      type: integer
     name: v1
     schema:
       openAPIV3Schema:
@@ -133,6 +143,25 @@ spec:
                             Specifies the maximum amount of resources that will be recommended
                             for the container. The default is no maximum.
                           type: object
+                        memoryAggregationIntervalCount:
+                          description: |-
+                            memoryAggregationIntervalCount is the number of consecutive
+                            memoryAggregationIntervals which make up the memory aggregation window.
+                            The total window length is:
+                            MemoryAggregationIntervalSeconds * MemoryAggregationIntervalCount.
+                          format: int64
+                          minimum: 1
+                          type: integer
+                        memoryAggregationIntervalSeconds:
+                          description: |-
+                            memoryAggregationIntervalSeconds is the length of a single interval
+                            (in seconds) for which the peak memory usage is computed.
+                            Memory usage peaks are aggregated in multiples of this interval.
+                            In other words, there is one memory usage sample per interval
+                            (the maximum usage over that interval).
+                          format: int32
+                          minimum: 1
+                          type: integer
                         minAllowed:
                           additionalProperties:
                             anyOf:
@@ -167,8 +196,113 @@ spec:
                             when OOM is detected.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        startupBoost:
+                          description: |-
+                            startupBoost specifies the startup boost policy for the container.
+                            This overrides any pod-level startup boost policy.
+                            The startup boost policy takes precedence over the rest of the fields in
+                            this struct, except for ContainerName and ControlledValues.
+                          properties:
+                            cpu:
+                              description: |-
+                                cpu specifies the CPU startup boost policy.
+                                If this field is not set, no startup boost is applied.
+                              properties:
+                                durationSeconds:
+                                  description: |-
+                                    durationSeconds indicates for how long to keep the pod boosted after it goes to Ready.
+                                    Defaults to 0.
+                                  format: int32
+                                  type: integer
+                                factor:
+                                  description: |-
+                                    factor specifies the factor to apply to the resource request.
+                                    This field is required when Type is "Factor".
+                                  format: int32
+                                  type: integer
+                                quantity:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    quantity specifies the absolute resource quantity to be used as the
+                                    resource request and limit during the boost phase.
+                                    This field is required when Type is "Quantity".
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: |-
+                                    type specifies the kind of boost to apply.
+                                    Supported values are: "Factor", "Quantity".
+                                    No startupboost will be applied for unrecognized values.
+                                  enum:
+                                  - Factor
+                                  - Quantity
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: factor is required when type is Factor and
+                                  forbidden otherwise
+                                rule: (self.type == 'Factor') == has(self.factor)
+                              - message: quantity is required when type is Quantity
+                                  and forbidden otherwise
+                                rule: (self.type == 'Quantity') == has(self.quantity)
+                          type: object
                       type: object
                     type: array
+                type: object
+              startupBoost:
+                description: startupBoost specifies the startup boost policy for the
+                  pod.
+                properties:
+                  cpu:
+                    description: |-
+                      cpu specifies the CPU startup boost policy.
+                      If this field is not set, no startup boost is applied.
+                    properties:
+                      durationSeconds:
+                        description: |-
+                          durationSeconds indicates for how long to keep the pod boosted after it goes to Ready.
+                          Defaults to 0.
+                        format: int32
+                        type: integer
+                      factor:
+                        description: |-
+                          factor specifies the factor to apply to the resource request.
+                          This field is required when Type is "Factor".
+                        format: int32
+                        type: integer
+                      quantity:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          quantity specifies the absolute resource quantity to be used as the
+                          resource request and limit during the boost phase.
+                          This field is required when Type is "Quantity".
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type:
+                        description: |-
+                          type specifies the kind of boost to apply.
+                          Supported values are: "Factor", "Quantity".
+                          No startupboost will be applied for unrecognized values.
+                        enum:
+                        - Factor
+                        - Quantity
+                        type: string
+                    required:
+                    - type
+                    type: object
+                    x-kubernetes-validations:
+                    - message: factor is required when type is Factor and forbidden
+                        otherwise
+                      rule: (self.type == 'Factor') == has(self.factor)
+                    - message: quantity is required when type is Quantity and forbidden
+                        otherwise
+                      rule: (self.type == 'Quantity') == has(self.quantity)
                 type: object
               targetRef:
                 description: |-
@@ -204,6 +338,14 @@ spec:
                   If not specified, all fields in the `PodUpdatePolicy` are set to their
                   default values.
                 properties:
+                  evictAfterOOMSeconds:
+                    description: |-
+                      evictAfterOOMSeconds specifies the time in seconds to wait after an OOM event before
+                      considering the pod for eviction. Pods that have OOMed in less than this time
+                      since start will be evicted.
+                    format: int32
+                    minimum: 1
+                    type: integer
                   evictionRequirements:
                     description: |-
                       EvictionRequirements is a list of EvictionRequirements that need to
@@ -254,6 +396,7 @@ spec:
                     - Initial
                     - Recreate
                     - InPlaceOrRecreate
+                    - InPlace
                     - Auto
                     type: string
                 type: object
@@ -283,6 +426,14 @@ spec:
                         message is a human-readable explanation containing details about
                         the transition
                       type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
                     reason:
                       description: reason is the reason for the condition's last transition.
                       type: string
@@ -298,6 +449,12 @@ spec:
                   - type
                   type: object
                 type: array
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  by this autoscaler.
+                format: int64
+                minimum: 0
+                type: integer
               recommendation:
                 description: |-
                   The most recently computed amount of resources recommended by the

--- a/test/integration/testdata/upstream-crds/10-crd-extensions.gardener.cloud_controlplanes.yaml
+++ b/test/integration/testdata/upstream-crds/10-crd-extensions.gardener.cloud_controlplanes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: controlplanes.extensions.gardener.cloud
 spec:
   group: extensions.gardener.cloud

--- a/test/integration/testdata/upstream-crds/10-crd-resources.gardener.cloud_managedresources.yaml
+++ b/test/integration/testdata/upstream-crds/10-crd-resources.gardener.cloud_managedresources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: managedresources.resources.gardener.cloud
 spec:
   group: resources.gardener.cloud


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
This change puts the CRDs needed for the compatibility-related tests into the `upstream-crds` make target.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
