### PR TITLE
Add support for Machine Preservation

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -250,6 +250,11 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				}
 			}
 
+			var preserveMax int32
+			if pool.MachineControllerManagerSettings != nil {
+				preserveMax = ptr.Deref(pool.MachineControllerManagerSettings.AutoPreserveFailedMachineMax, 0)
+			}
+
 			machineDeployments = append(machineDeployments, worker.MachineDeployment{
 				Name:                         deploymentName,
 				ClassName:                    className,
@@ -264,6 +269,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				Taints:                       pool.Taints,
 				MachineConfiguration:         genericworkeractuator.ReadMachineConfiguration(pool),
 				ClusterAutoscalerAnnotations: extensionsv1alpha1helper.GetMachineDeploymentClusterAutoscalerAnnotations(pool.ClusterAutoscaler),
+				AutoPreserveFailedMachineMax: worker.DistributeOverZones(zoneIdx, preserveMax, zoneLen),
 			})
 
 			machineClassSpec["name"] = className

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -1164,6 +1164,43 @@ var _ = Describe("Machines", func() {
 				Expect(result[1].ClusterAutoscalerAnnotations[extensionsv1alpha1.ScaleDownUtilizationThresholdAnnotation]).To(Equal("0.5"))
 			})
 
+			It("should distribute autoPreserveFailedMachineMax across zones", func() {
+				w.Spec.Pools[0].MachineControllerManagerSettings = &gardencorev1beta1.MachineControllerManagerSettings{
+					AutoPreserveFailedMachineMax: new(int32(4)),
+				}
+				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, "")
+
+				result, err := workerDelegate.GenerateMachineDeployments(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result[0].AutoPreserveFailedMachineMax).To(Equal(int32(2)))
+				Expect(result[1].AutoPreserveFailedMachineMax).To(Equal(int32(2)))
+			})
+
+			It("should set autoPreserveFailedMachineMax to 0 per zone when machineControllerManagerSettings is nil", func() {
+				w.Spec.Pools[0].MachineControllerManagerSettings = nil
+				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, "")
+
+				result, err := workerDelegate.GenerateMachineDeployments(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result[0].AutoPreserveFailedMachineMax).To(Equal(int32(0)))
+				Expect(result[1].AutoPreserveFailedMachineMax).To(Equal(int32(0)))
+			})
+
+			It("should set autoPreserveFailedMachineMax to 0 per zone when autoPreserveFailedMachineMax is nil", func() {
+				w.Spec.Pools[0].MachineControllerManagerSettings = &gardencorev1beta1.MachineControllerManagerSettings{
+					AutoPreserveFailedMachineMax: nil,
+				}
+				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, "")
+
+				result, err := workerDelegate.GenerateMachineDeployments(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result[0].AutoPreserveFailedMachineMax).To(Equal(int32(0)))
+				Expect(result[1].AutoPreserveFailedMachineMax).To(Equal(int32(0)))
+			})
+
 			DescribeTable("customLabelDomain in machineclass helm chart",
 				func(customDomain string) {
 					workerDelegate, _ := NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customDomain)


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement
/cc @timebertt 
/cc @stackitcloud/ske-infrastructure 

**What this PR does / why we need it**:
This PR adds support for the Machine Preservation feature. 

gardener PR: https://github.com/gardener/gardener/pull/14767
Other PR for the same feature: https://github.com/gardener/gardener-extension-provider-gcp/pull/1475

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
