### PR TITLE
Skip shoot validation for workerless shoots

### DIFF
--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	gardencorehelper "github.com/gardener/gardener/pkg/api/core/helper"
 	"github.com/gardener/gardener/pkg/apis/core"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
@@ -35,6 +36,11 @@ func (s *shoot) Validate(_ context.Context, newObj, oldObj client.Object) error 
 	shoot, ok := newObj.(*core.Shoot)
 	if !ok {
 		return fmt.Errorf("wrong object type %T", newObj)
+	}
+
+	// Skip if it's a workerless Shoot
+	if gardencorehelper.IsWorkerless(shoot) {
+		return nil
 	}
 
 	cpConfig, err := helper.ControlPlaneConfigFromRawExtension(shoot.Spec.Provider.ControlPlaneConfig)

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -68,6 +68,11 @@ var _ = Describe("NamespacedCloudProfile Validator", func() {
 					InfrastructureConfig: &runtime.RawExtension{
 						Raw: encode(&infrastructureConfig),
 					},
+					Workers: []core.Worker{
+						{
+							Name: "worker",
+						},
+					},
 				},
 				Networking: &core.Networking{Nodes: new("10.0.0.0/24")},
 			},
@@ -126,6 +131,15 @@ var _ = Describe("NamespacedCloudProfile Validator", func() {
 			newShoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{Raw: encode(&infrastructureConfig)}
 
 			Expect(shootValidator.Validate(ctx, newShoot, shoot)).To(Not(Succeed()))
+		})
+
+		It("should skip with workerless shoot", func() {
+			// this would be invalid for a shoot with workers
+			infrastructureConfig.Networks.Workers = ""
+			shoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{Raw: encode(&infrastructureConfig)}
+			shoot.Spec.Provider.Workers = []core.Worker{}
+
+			Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

/cc @timebertt 
/cc @stackitcloud/ske-infrastructure 

**What this PR does / why we need it**:
Workerless shoots don't need to be validated. This PR adds a skip of the validation for workerless shoots.

Same as GCP: https://github.com/gardener/gardener-extension-provider-gcp/blob/be7716db1a4085a5a5a35b8854c0943472983472/pkg/admission/validator/shoot.go#L69

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
