### PR TITLE
Updated VPA resources updateMode to `InPlaceOrRecreate`

### DIFF
--- a/charts/gardener-extension-admission-stackit/charts/runtime/values.yaml
+++ b/charts/gardener-extension-admission-stackit/charts/runtime/values.yaml
@@ -12,7 +12,7 @@ healthPort: 8081
 vpa:
   enabled: true
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "InPlaceOrRecreate"
 webhookConfig:
   serverPort: 10250
   servicePort: 443

--- a/charts/gardener-extension-provider-stackit/values.yaml
+++ b/charts/gardener-extension-provider-stackit/values.yaml
@@ -11,7 +11,7 @@ extraEnvs: []
 vpa:
   enabled: true
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "InPlaceOrRecreate"
 
 metricsPort: "{{ index .Values.usablePorts 0 }}"
 healthPort: "{{ index .Values.usablePorts 1 }}"

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/vpa.yaml
@@ -9,7 +9,7 @@ spec:
     kind: Deployment
     name: cloud-controller-manager
   updatePolicy:
-    updateMode: Auto
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: openstack-cloud-controller-manager

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-vpa.yaml
@@ -24,4 +24,4 @@ spec:
     kind: Deployment
     name: csi-driver-controller
   updatePolicy:
-    updateMode: Auto
+    updateMode: InPlaceOrRecreate

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-controller-vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-controller-vpa.yaml
@@ -14,4 +14,4 @@ spec:
     kind: Deployment
     name: csi-snapshot-controller
   updatePolicy:
-    updateMode: Auto
+    updateMode: InPlaceOrRecreate

--- a/charts/internal/seed-controlplane/charts/stackit-application-load-balancer-controller/templates/vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/stackit-application-load-balancer-controller/templates/vpa.yaml
@@ -9,7 +9,7 @@ spec:
     kind: Deployment
     name: stackit-application-load-balancer-controller
   updatePolicy:
-    updateMode: Auto
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: stackit-application-load-balancer-controller

--- a/charts/internal/seed-controlplane/charts/stackit-blockstorage-csi-driver/templates/csi-driver-controller-vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/stackit-blockstorage-csi-driver/templates/csi-driver-controller-vpa.yaml
@@ -23,4 +23,4 @@ spec:
     kind: Deployment
     name: {{.Values.prefix}}-csi-driver-controller
   updatePolicy:
-    updateMode: Auto
+    updateMode: InPlaceOrRecreate

--- a/charts/internal/seed-controlplane/charts/stackit-blockstorage-csi-driver/templates/csi-snapshot-controller-vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/stackit-blockstorage-csi-driver/templates/csi-snapshot-controller-vpa.yaml
@@ -14,5 +14,5 @@ spec:
     kind: Deployment
     name: {{.Values.prefix}}-csi-snapshot-controller
   updatePolicy:
-    updateMode: Auto
+    updateMode: InPlaceOrRecreate
 {{- end }}

--- a/charts/internal/seed-controlplane/charts/stackit-cloud-controller-manager/templates/vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/stackit-cloud-controller-manager/templates/vpa.yaml
@@ -9,7 +9,7 @@ spec:
     kind: Deployment
     name: stackit-cloud-controller-manager
   updatePolicy:
-    updateMode: Auto
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: stackit-cloud-controller-manager


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup
/cc @stackitcloud/ske-infrastructure 

**What this PR does / why we need it**:
This PR sets `InPlaceOrRecreate` to all VPA objects. 
This is currently done by a webhook in GRM which will be removed at some point, when all extensions have set it to `InPlaceOrRecreate`.

There is an ☂️  issue on gardener for this: https://github.com/gardener/gardener/issues/12955 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
