### PR TITLE
Disable featureGate MutateDisableNTP to prepare for complete removal of the webhook

### DIFF
--- a/pkg/admission/mutator/shoot_test.go
+++ b/pkg/admission/mutator/shoot_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/feature"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -40,6 +41,7 @@ var _ = Describe("Shoot mutator", func() {
 			scheme := runtime.NewScheme()
 			Expect(gardencorev1beta1.AddToScheme(scheme)).To(Succeed())
 			Expect(configv1alpha1.AddToScheme(scheme)).To(Succeed())
+			DeferCleanup(testutils.WithFeatureGate(feature.MutableGate, feature.MutateDisableNTP, true))
 
 			mgr = &testutils.FakeManager{Scheme: scheme}
 

--- a/pkg/admission/mutator/shoot_test.go
+++ b/pkg/admission/mutator/shoot_test.go
@@ -12,12 +12,12 @@ import (
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/feature"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 
+	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/feature"
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit"
 )
 

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -46,7 +46,7 @@ var (
 	Gate featuregate.FeatureGate = MutableGate
 
 	allGates = map[featuregate.Feature]featuregate.FeatureSpec{
-		MutateDisableNTP:                      {Default: true, PreRelease: featuregate.Alpha},
+		MutateDisableNTP:                      {Default: false, PreRelease: featuregate.Alpha},
 		EnsureSTACKITLBDeletion:               {Default: true, PreRelease: featuregate.Alpha},
 		EnsureSTACKITALBDeletion:              {Default: false, PreRelease: featuregate.Alpha},
 		UseSTACKITAPIInfrastructureController: {Default: true, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement

**What this PR does / why we need it**:

Disables the `MutateDisableNTP` webhook by default. All SKE Images now support `PTP` and it will be enabled by default.
This PR prepares the removal of the entire webhook in a non breaking manner.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:


