### PR TITLE
Introduce new field `DNSServers` into `InfrastructureStatus`

### DIFF
--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -2010,6 +2010,7 @@ string
 
 <p>
 ShareNetwork holds information about the share network (used for shared file systems like NFS)
+
 Deprecated: Unused and will be removed later on
 </p>
 

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -1513,7 +1513,7 @@ string
 </em>
 </td>
 <td>
-<p>Subnets is a list of subnets that have been created.<br />Deprecated: Will be removed once fully migrated to IaaS API</p>
+<p>Subnets is a list of subnets that have been created.<br />Deprecated: OpenStack-only; not used for STACKIT.</p>
 </td>
 </tr>
 <tr>

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -1495,13 +1495,25 @@ string
 </tr>
 <tr>
 <td>
+<code>dnsServers</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DNSServer contains the networks configured dnsServers</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>subnets</code></br>
 <em>
 <a href="#subnet">Subnet</a> array
 </em>
 </td>
 <td>
-<p>Subnets is a list of subnets that have been created.</p>
+<p>Subnets is a list of subnets that have been created.<br />Deprecated: Will be removed once fully migrated to IaaS API</p>
 </td>
 </tr>
 <tr>
@@ -1513,7 +1525,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ShareNetwork contains information about a created/provided ShareNetwork</p>
+<p>ShareNetwork contains information about a created/provided ShareNetwork<br />Deprecated: Unused and will be removed later on</p>
 </td>
 </tr>
 
@@ -1609,7 +1621,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ShareNetwork holds information about the share network (used for shared file systems like NFS)</p>
+<p>ShareNetwork holds information about the share network (used for shared file systems like NFS)<br />Deprecated: Unused and will be removed later on</p>
 </td>
 </tr>
 <tr>
@@ -1998,6 +2010,7 @@ string
 
 <p>
 ShareNetwork holds information about the share network (used for shared file systems like NFS)
+Deprecated: Unused and will be removed later on
 </p>
 
 <table>

--- a/pkg/apis/stackit/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/stackit/v1alpha1/types_infrastructure.go
@@ -43,6 +43,8 @@ type Networks struct {
 	SubnetID *string `json:"subnetId,omitempty"`
 	// ShareNetwork holds information about the share network (used for shared file systems like NFS)
 	// +optional
+	//
+	// Deprecated: Unused and will be removed later on
 	ShareNetwork *ShareNetwork `json:"shareNetwork,omitempty"`
 	// DNSServers overrides the default dns configuration from cloud profile
 	// +optional
@@ -56,6 +58,8 @@ type Router struct {
 }
 
 // ShareNetwork holds information about the share network (used for shared file systems like NFS)
+//
+// Deprecated: Unused and will be removed later on
 type ShareNetwork struct {
 	// Enabled is the switch to enable the creation of a share network
 	Enabled bool `json:"enabled"`
@@ -90,10 +94,17 @@ type NetworkStatus struct {
 	FloatingPool FloatingPoolStatus `json:"floatingPool"`
 	// Router contains information about the Router and related resources.
 	Router RouterStatus `json:"router"`
+	// DNSServer contains the networks configured dnsServers
+	// +optional
+	DNSServers *[]string `json:"dnsServers,omitempty"`
 	// Subnets is a list of subnets that have been created.
+	//
+	// Deprecated: Will be removed once fully migrated to IaaS API
 	Subnets []Subnet `json:"subnets"`
 	// ShareNetwork contains information about a created/provided ShareNetwork
 	// +optional
+	//
+	// Deprecated: Unused and will be removed later on
 	ShareNetwork *ShareNetworkStatus `json:"shareNetwork,omitempty"`
 }
 

--- a/pkg/apis/stackit/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/stackit/v1alpha1/types_infrastructure.go
@@ -99,7 +99,7 @@ type NetworkStatus struct {
 	DNSServers *[]string `json:"dnsServers,omitempty"`
 	// Subnets is a list of subnets that have been created.
 	//
-	// Deprecated: Will be removed once fully migrated to IaaS API
+	// Deprecated: OpenStack-only; not used for STACKIT.
 	Subnets []Subnet `json:"subnets"`
 	// ShareNetwork contains information about a created/provided ShareNetwork
 	// +optional

--- a/pkg/apis/stackit/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/stackit/v1alpha1/zz_generated.deepcopy.go
@@ -660,6 +660,15 @@ func (in *NetworkStatus) DeepCopyInto(out *NetworkStatus) {
 	*out = *in
 	out.FloatingPool = in.FloatingPool
 	in.Router.DeepCopyInto(&out.Router)
+	if in.DNSServers != nil {
+		in, out := &in.DNSServers, &out.DNSServers
+		*out = new([]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]string, len(*in))
+			copy(*out, *in)
+		}
+	}
 	if in.Subnets != nil {
 		in, out := &in.Subnets, &out.Subnets
 		*out = make([]Subnet, len(*in))

--- a/pkg/controller/infrastructure/openstack/infraflow/context.go
+++ b/pkg/controller/infrastructure/openstack/infraflow/context.go
@@ -205,7 +205,7 @@ func (fctx *FlowContext) computeInfrastructureStatus() *stackitv1alpha1.Infrastr
 	}
 
 	if v := fctx.state.Get(IdentifierSubnet); v != nil {
-		//nolint:staticcheck // SA1019: Remove once cluster-controller does not use that field anymore
+		//nolint:staticcheck // SA1019: Keep support for OpenStack mcm until we completely drop it
 		status.Networks.Subnets = []stackitv1alpha1.Subnet{
 			{
 				Purpose:        stackitv1alpha1.PurposeNodes,

--- a/pkg/controller/infrastructure/openstack/infraflow/context.go
+++ b/pkg/controller/infrastructure/openstack/infraflow/context.go
@@ -200,7 +200,12 @@ func (fctx *FlowContext) computeInfrastructureStatus() *stackitv1alpha1.Infrastr
 
 	status.Node.KeyName = ptr.Deref(fctx.state.Get(NameKeyPair), "")
 
+	if fctx.dnsNameservers != nil {
+		status.Networks.DNSServers = fctx.dnsNameservers
+	}
+
 	if v := fctx.state.Get(IdentifierSubnet); v != nil {
+		//nolint:staticcheck // SA1019: Remove once cluster-controller does not use that field anymore
 		status.Networks.Subnets = []stackitv1alpha1.Subnet{
 			{
 				Purpose:        stackitv1alpha1.PurposeNodes,

--- a/pkg/controller/infrastructure/stackit/infraflow/context.go
+++ b/pkg/controller/infrastructure/stackit/infraflow/context.go
@@ -180,7 +180,13 @@ func (fctx *FlowContext) computeInfrastructureStatus() *stackitv1alpha1.Infrastr
 
 	status.Node.KeyName = ptr.Deref(fctx.state.Get(NameKeyPair), "")
 
+	if fctx.dnsNameservers != nil {
+		status.Networks.DNSServers = fctx.dnsNameservers
+	}
+
+	// TODO: Remove once migrated fully to IaaS API
 	if v := fctx.state.Get(IdentifierSubnet); v != nil {
+		//nolint:staticcheck // SA1019: Remove once cluster-controller does not use that field anymore
 		status.Networks.Subnets = []stackitv1alpha1.Subnet{
 			{
 				Purpose:        stackitv1alpha1.PurposeNodes,

--- a/pkg/controller/infrastructure/stackit/infraflow/context.go
+++ b/pkg/controller/infrastructure/stackit/infraflow/context.go
@@ -186,7 +186,7 @@ func (fctx *FlowContext) computeInfrastructureStatus() *stackitv1alpha1.Infrastr
 
 	// TODO: Remove once migrated fully to IaaS API
 	if v := fctx.state.Get(IdentifierSubnet); v != nil {
-		//nolint:staticcheck // SA1019: Remove once cluster-controller does not use that field anymore
+		//nolint:staticcheck // SA1019: Will be removed once OpenStack mcm support is dropped.
 		status.Networks.Subnets = []stackitv1alpha1.Subnet{
 			{
 				Purpose:        stackitv1alpha1.PurposeNodes,

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -95,6 +95,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 	var subnet *stackitv1alpha1.Subnet
 	// There is no subnet resource in the IaaS API. The machine-controller-manager-provider-stackit do not require this field.
 	if !feature.UseStackitMachineControllerManager(w.cluster) {
+		//nolint:staticcheck // SA1019: Remove once cluster-controller does not use that field anymore
 		subnet, err = helper.FindSubnetByPurpose(infrastructureStatus.Networks.Subnets, stackitv1alpha1.PurposeNodes)
 		if err != nil {
 			return err

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -95,7 +95,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 	var subnet *stackitv1alpha1.Subnet
 	// There is no subnet resource in the IaaS API. The machine-controller-manager-provider-stackit do not require this field.
 	if !feature.UseStackitMachineControllerManager(w.cluster) {
-		//nolint:staticcheck // SA1019: Remove once cluster-controller does not use that field anymore
+		//nolint:staticcheck // SA1019: Will be removed once we drop OpenStack API support
 		subnet, err = helper.FindSubnetByPurpose(infrastructureStatus.Networks.Subnets, stackitv1alpha1.PurposeNodes)
 		if err != nil {
 			return err


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement

**What this PR does / why we need it**:

The `Subnet` field from the `InfrastructureStatus` will be removed, since the concept of a `Subnet` doesn't exist anymore in the new IaaS API. Additionally I also marked the **completely unused** fields of `ShareNetwork` as deprecated.

This new PR adds a new field called `DNSServer` of type `[]string` so we can save the `DNSServer` to the InfrastructureStatus, which is needed in the SKE internally developed cluster-error controller.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:
