### PR TITLE
Prepare workload identity federation for integration tests

### DIFF
--- a/test/project-wrapper/main.go
+++ b/test/project-wrapper/main.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"slices"
+	"strings"
 	"syscall"
 	"time"
 
@@ -32,11 +34,11 @@ The project will be deleted after the tests have run.
 # Required environment variables:
 
 STACKIT_REGION: the region of the STACKIT API endpoint, usually `eu01`
-STACKIT_SERVICE_ACCOUNT_TOKEN: service account token with permissions to create projects in `PORTAL_FOLDER_ID`
-STACKIT_SERVICE_ACCOUNT_EMAIL: the e-mail address of the service account token
 BILLING_REFERENCE: a valid billing reference for the created portal project
 PROJECT_OWNER: string representing how is responsible for the created account
 PORTAL_FOLDER_ID: the folder in the portal overview in which the integration portal project will be created
+
+Credentials that are auto-detected by the STACKIT SDK with permissions to create projects in `PORTAL_FOLDER_ID`
 */
 
 const (
@@ -91,7 +93,13 @@ func run() error {
 	// in our case this is expected behavior and the risk of malicious behavior
 	// is limited in our CI tooling. Therefore, we can ignore it.
 	cmd := exec.CommandContext(ctx, os.Args[1], os.Args[2:]...) // #nosec G204 G702
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(
+		// remove `STACKIT_SERVICE_ACCOUNT_EMAIL` to prevent using workflow identity path
+		slices.DeleteFunc(os.Environ(), func(env string) bool {
+			return strings.HasPrefix(env, "STACKIT_SERVICE_ACCOUNT_EMAIL=")
+		}),
+		// also shadow the federated token file
+		"STACKIT_FEDERATED_TOKEN_FILE=/dev/null",
 		fmt.Sprintf("STACKIT_SERVICE_ACCOUNT_KEY=%s", saKeyJSON),
 		fmt.Sprintf("STACKIT_PROJECT_ID=%s", stackitProjectID),
 	)


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

Prepare integration tests to allow injecting the service account credentials for the project creation using workload identity federation. As the actual test should use the service account created by the test wrapper, overwrite the environment [variables checked by the STACKIT SDK](https://github.com/stackitcloud/stackit-sdk-go/blob/401fa8f1bd2f202b6668eb0c99f17bd9bcd770de/core/clients/workload_identity_flow.go#L165) such that the workload identity is no longer detected.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
