### PR TITLE
chore: Increase --machine-creation-timout to 45m

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -126,6 +126,10 @@ func (e *ensurer) EnsureMachineControllerManagerDeployment(ctx context.Context, 
 		sidecarContainer.Args,
 		"--resource-exhausted-retry=", "30m",
 	)
+	sidecarContainer.Args = extensionswebhook.EnsureStringWithPrefix(
+		sidecarContainer.Args,
+		"--machine-creation-timeout=", "45m",
+	)
 
 	newObj.Spec.Template.Spec.Containers = extensionswebhook.EnsureContainerWithName(
 		newObj.Spec.Template.Spec.Containers,

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -563,6 +563,9 @@ WantedBy=multi-user.target
 			expectedContainer.Args = extensionswebhook.EnsureStringWithPrefix(
 				expectedContainer.Args, "--resource-exhausted-retry=", "30m",
 			)
+			expectedContainer.Args = extensionswebhook.EnsureStringWithPrefix(
+				expectedContainer.Args, "--machine-creation-timeout=", "45m",
+			)
 			Expect(deployment.Spec.Template.Spec.Containers).To(ConsistOf(expectedContainer))
 		})
 	})
@@ -608,6 +611,9 @@ WantedBy=multi-user.target
 			expectedContainer.Args = extensionswebhook.EnsureStringWithPrefix(
 				expectedContainer.Args, "--resource-exhausted-retry=", "30m",
 			)
+			expectedContainer.Args = extensionswebhook.EnsureStringWithPrefix(
+				expectedContainer.Args, "--machine-creation-timeout=", "45m",
+			)
 			Expect(deployment.Spec.Template.Spec.Containers).To(ConsistOf(expectedContainer))
 		})
 
@@ -618,6 +624,9 @@ WantedBy=multi-user.target
 			expectedContainer.Env = []corev1.EnvVar{}
 			expectedContainer.Args = extensionswebhook.EnsureStringWithPrefix(
 				expectedContainer.Args, "--resource-exhausted-retry=", "30m",
+			)
+			expectedContainer.Args = extensionswebhook.EnsureStringWithPrefix(
+				expectedContainer.Args, "--machine-creation-timeout=", "45m",
 			)
 			expectedContainer.VolumeMounts = append(expectedContainer.VolumeMounts, corev1.VolumeMount{
 				Name:      CAVolumeName,
@@ -686,6 +695,9 @@ WantedBy=multi-user.target
 			}
 			expectedContainer.Args = extensionswebhook.EnsureStringWithPrefix(
 				expectedContainer.Args, "--resource-exhausted-retry=", "30m",
+			)
+			expectedContainer.Args = extensionswebhook.EnsureStringWithPrefix(
+				expectedContainer.Args, "--machine-creation-timeout=", "45m",
 			)
 			Expect(deployment.Spec.Template.Spec.Containers).To(ConsistOf(expectedContainer))
 		})


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug

**What this PR does / why we need it**:
To reduce load on openstack we need to allow machines to stay in creation for a longer time. Increasing the `--machine-creation-timout` to 45m results in a higher chance of getting the creation through.


