### PR TITLE
Fix integration test run using workflow identity

### DIFF
--- a/test/project-wrapper/main.go
+++ b/test/project-wrapper/main.go
@@ -119,7 +119,6 @@ func run() error {
 func checkRequiredEnvironmentVariables() error {
 	requiredVars := []string{
 		"STACKIT_REGION",
-		"STACKIT_SERVICE_ACCOUNT_KEY",
 		"STACKIT_SERVICE_ACCOUNT_EMAIL",
 		"BILLING_REFERENCE",
 		"PROJECT_OWNER",


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:

With workflow identity, the project-wrapper no longer receives a `STACKIT_SERVICE_ACCOUNT_KEY` environment variable.

**Which issue(s) this PR fixes**:
Fixup for https://github.com/stackitcloud/gardener-extension-provider-stackit/pull/251

**Special notes for your reviewer**:
The actual tests still check for `STACKIT_SERVICE_ACCOUNT_KEY`, which is fine as the environment variable is injected by the project-wrapper.