### PR TITLE
Add service for application-load-balancer-controller

### DIFF
--- a/charts/internal/seed-controlplane/charts/stackit-application-load-balancer-controller/templates/stackit-application-load-balancer-controller-svc.yaml
+++ b/charts/internal/seed-controlplane/charts/stackit-application-load-balancer-controller/templates/stackit-application-load-balancer-controller-svc.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: stackit-application-load-balancer-controller
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports: '[{"port":{{ .Values.metricsPort }},"protocol":"TCP"}]'
+  labels:
+    app: kubernetes
+    role: stackit-application-load-balancer-controller
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: {{ .Values.metricsPort }}
+    protocol: TCP
+  selector:
+    app: kubernetes
+    role: stackit-application-load-balancer-controller


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement
/cc @stackitcloud/ske-infrastructure 

**What this PR does / why we need it**:
To be able to scrape the metrics of the `application-load-balancer-controller` we need a service with the `networking.resources.gardener.cloud` annotation. This PR adds this service.

