### PR TITLE
Adopt service to be able scrape from secure port in CCM

### DIFF
--- a/charts/internal/seed-controlplane/charts/stackit-cloud-controller-manager/templates/stackit-cloud-controller-manager-svc.yaml
+++ b/charts/internal/seed-controlplane/charts/stackit-cloud-controller-manager/templates/stackit-cloud-controller-manager-svc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: stackit-cloud-controller-manager
   namespace: {{ .Release.Namespace }}
   annotations:
-    networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports: '[{"port":{{ .Values.config.metricsPort }},"protocol":"TCP"}]'
+    networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports: '[{"port":{{ .Values.config.metricsPort }},"protocol":"TCP"},{"port":{{ .Values.config.port }},"protocol":"TCP"}]'
   labels:
     app: kubernetes
     role: stackit-cloud-controller-manager
@@ -14,6 +14,9 @@ spec:
   ports:
   - name: metrics
     port: {{ .Values.config.metricsPort }}
+    protocol: TCP
+  - name: https
+    port: {{ .Values.config.port }}
     protocol: TCP
   selector:
     app: kubernetes

--- a/charts/internal/seed-controlplane/charts/stackit-cloud-controller-manager/templates/stackit-cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/stackit-cloud-controller-manager/templates/stackit-cloud-controller-manager.yaml
@@ -54,6 +54,7 @@ spec:
         - --cloud-config=/etc/config/cloud.yaml
         - --cluster-name={{ .Values.technicalID }}
         - --metrics-address=:{{ .Values.config.metricsPort }}
+        - --secure-port={{ .Values.config.port }}
         {{- include "stackit-cloud-controller-manager.featureGates" . | trimSuffix "," | indent 8 }}
         {{- include "stackit-cloud-controller-manager.controllers" . | trimSuffix "," | indent 8 }}
         env:


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement
/cc @stackitcloud/ske-infrastructure 

**What this PR does / why we need it**:
Add already existing `--secure-port` port to service and also allow scraping from it. Can old `--metrics-address` can be removed later when PR https://github.com/stackitcloud/cloud-provider-stackit/pull/1515 is merged, released and updated in this repo.

