### PR TITLE
Add junit.xml in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,9 @@ hack/generate-controller-registration.sh
 *.so
 *.dylib
 
-# Test binary, built with `go test -c`
+# Test binary, built with `go test -c` and reports
 *.test
+junit.xml
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement
/cc @xoxys 

**What this PR does / why we need it**:
This adds junit.xml in .gitignore
junit.xml are generated when the CI variable is set while `make test` to provide a better machine readable output. This adds the junit.xml to gitignore as we don't want to push them when we have them locally

