### PR TITLE
migrate mcm-provider from openstack to stackit

### DIFF
--- a/pkg/controller/worker/actuator.go
+++ b/pkg/controller/worker/actuator.go
@@ -14,6 +14,8 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	gardener "github.com/gardener/gardener/pkg/client/kubernetes"
+	openstackclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/openstack/client"
+	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes"
@@ -24,7 +26,7 @@ import (
 
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/apis/stackit/helper"
 	stackitv1alpha1 "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/apis/stackit/v1alpha1"
-	openstackclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/openstack/client"
+	stackitclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit/client"
 )
 
 type delegateFactory struct {
@@ -71,6 +73,8 @@ func (d *delegateFactory) WorkerDelegate(ctx context.Context, worker *extensions
 		return nil, err
 	}
 
+	stackitClient := stackitclient.New(stackit.DetermineRegion(cluster), cluster)
+
 	return NewWorkerDelegate(
 		d.seedClient,
 		d.scheme,
@@ -81,6 +85,7 @@ func (d *delegateFactory) WorkerDelegate(ctx context.Context, worker *extensions
 		worker,
 		cluster,
 		d.customLabelDomain,
+		stackitClient,
 	)
 }
 
@@ -102,6 +107,7 @@ type workerDelegate struct {
 	machineImages      []stackitv1alpha1.MachineImage
 
 	openstackClient openstackclient.Factory
+	stackitClient   stackitclient.Factory
 }
 
 // NewWorkerDelegate creates a new context for a worker reconciliation.
@@ -115,6 +121,7 @@ func NewWorkerDelegate(
 	worker *extensionsv1alpha1.Worker,
 	cluster *extensionscontroller.Cluster,
 	customLabelDomain string,
+	stackitClient stackitclient.Factory,
 ) (genericactuator.WorkerDelegate, error) {
 	config, err := helper.CloudProfileConfigFromCluster(cluster)
 	if err != nil {
@@ -133,5 +140,6 @@ func NewWorkerDelegate(
 		cluster:            cluster,
 		worker:             worker,
 		customLabelDomain:  customLabelDomain,
+		stackitClient:      stackitClient,
 	}, nil
 }

--- a/pkg/controller/worker/actuator.go
+++ b/pkg/controller/worker/actuator.go
@@ -74,6 +74,10 @@ func (d *delegateFactory) WorkerDelegate(ctx context.Context, worker *extensions
 	}
 
 	stackitClient := stackitclient.New(stackit.DetermineRegion(cluster), cluster)
+	iaasClient, err := stackitClient.IaaS(ctx, d.seedClient, worker.Spec.SecretRef)
+	if err != nil {
+		return nil, err
+	}
 
 	return NewWorkerDelegate(
 		d.seedClient,
@@ -85,7 +89,7 @@ func (d *delegateFactory) WorkerDelegate(ctx context.Context, worker *extensions
 		worker,
 		cluster,
 		d.customLabelDomain,
-		stackitClient,
+		iaasClient,
 	)
 }
 
@@ -107,7 +111,7 @@ type workerDelegate struct {
 	machineImages      []stackitv1alpha1.MachineImage
 
 	openstackClient openstackclient.Factory
-	stackitClient   stackitclient.Factory
+	iaaSClient      stackitclient.IaaSClient
 }
 
 // NewWorkerDelegate creates a new context for a worker reconciliation.
@@ -121,7 +125,7 @@ func NewWorkerDelegate(
 	worker *extensionsv1alpha1.Worker,
 	cluster *extensionscontroller.Cluster,
 	customLabelDomain string,
-	stackitClient stackitclient.Factory,
+	iaaSClient stackitclient.IaaSClient,
 ) (genericactuator.WorkerDelegate, error) {
 	config, err := helper.CloudProfileConfigFromCluster(cluster)
 	if err != nil {
@@ -140,6 +144,6 @@ func NewWorkerDelegate(
 		cluster:            cluster,
 		worker:             worker,
 		customLabelDomain:  customLabelDomain,
-		stackitClient:      stackitClient,
+		iaaSClient:         iaaSClient,
 	}, nil
 }

--- a/pkg/controller/worker/actuator.go
+++ b/pkg/controller/worker/actuator.go
@@ -14,8 +14,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	gardener "github.com/gardener/gardener/pkg/client/kubernetes"
-	openstackclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/openstack/client"
-	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes"
@@ -26,6 +24,8 @@ import (
 
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/apis/stackit/helper"
 	stackitv1alpha1 "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/apis/stackit/v1alpha1"
+	openstackclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/openstack/client"
+	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit"
 	stackitclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit/client"
 )
 

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -77,6 +77,7 @@ func (w *workerDelegate) DeployMachineClasses(ctx context.Context) error {
 	}
 
 	if feature.MigrateStackitMachineControllerManager(w.cluster) && w.worker.Annotations[workerMigratedAnnotation] != "true" {
+		fmt.Println("Migrating Stackit Machine Controller Manager to Gardener Machine Controller Manager...")
 		err = w.migrateMachines(ctx)
 		if err != nil {
 			return err

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -74,7 +74,7 @@ func (w *workerDelegate) DeployMachineClasses(ctx context.Context) error {
 		return err
 	}
 
-	if feature.MigrateStackitMachineControllerManager(w.cluster) {
+	if feature.MigrateStackitMachineControllerManager(w.cluster) && w.worker.Annotations[workerMigratedAnnotation] != "true" {
 		err = w.migrateMachines(ctx)
 		if err != nil {
 			return err

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -76,8 +76,9 @@ func (w *workerDelegate) DeployMachineClasses(ctx context.Context) error {
 		return err
 	}
 
+	fmt.Println("Deploying OpenStack machine classes...")
 	if feature.MigrateStackitMachineControllerManager(w.cluster) && w.worker.Annotations[workerMigratedAnnotation] != "true" {
-		fmt.Println("Migrating Stackit Machine Controller Manager to Gardener Machine Controller Manager...")
+		fmt.Println("Migrating Stackit Machine Controller Manager to Gardener Machine Controller Manager...") // TODO: remove later
 		err = w.migrateMachines(ctx)
 		if err != nil {
 			return err

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -516,14 +516,20 @@ func (w *workerDelegate) markWorkerAsMigrated(ctx context.Context) error {
 
 func serverIDFromProviderID(providerID string) (string, error) {
 	patterns := []*regexp.Regexp{
-		regexp.MustCompile(`^openstack:///[^/]+/([^/]+)$`),
-		regexp.MustCompile(`^stackit://[^/]+/([^/]+)$`),
+		regexp.MustCompile(`^openstack:///[^/]+/(?P<serverID>[^/]+)$`),
+		regexp.MustCompile(`^stackit://[^/]+/(?P<serverID>[^/]+)$`),
 	}
 
 	for _, pattern := range patterns {
-		matches := pattern.FindStringSubmatch(providerID)
-		if len(matches) == 2 {
-			return matches[1], nil
+		match := pattern.FindStringSubmatch(providerID)
+		if len(match) == 0 {
+			continue
+		}
+
+		for i, name := range pattern.SubexpNames() {
+			if name == "serverID" {
+				return match[i], nil
+			}
 		}
 	}
 

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -40,6 +40,7 @@ import (
 
 const shouldMigrateMachineAnnotation = "stackit.cloud/machine-should-be-migrated"
 const migratedMachineAnnotation = "stackit.cloud/migrated-machine"
+const workerMigratedAnnotation = "stackit.cloud/machine-controller-manager-migrated"
 
 // MachineClassKind yields the name of the machine class kind used by OpenStack provider.
 func (w *workerDelegate) MachineClassKind() string {
@@ -495,5 +496,17 @@ func (w *workerDelegate) migrateMachines(ctx context.Context) error {
 		}
 	}
 
-	return nil
+	return w.markWorkerAsMigrated(ctx)
+}
+
+func (w *workerDelegate) markWorkerAsMigrated(ctx context.Context) error {
+	patchWorker := client.MergeFrom(w.worker.DeepCopy())
+
+	if w.worker.Annotations == nil {
+		w.worker.Annotations = make(map[string]string)
+	}
+
+	w.worker.Annotations[workerMigratedAnnotation] = "true"
+
+	return w.seedClient.Patch(ctx, w.worker, patchWorker)
 }

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
@@ -34,7 +35,11 @@ import (
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/openstack"
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit"
 	stackitutils "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/utils"
+	iaas2 "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
 )
+
+const shouldMigrateMachineAnnotation = "stackit.cloud/machine-should-be-migrated"
+const migratedMachineAnnotation = "stackit.cloud/migrated-machine"
 
 // MachineClassKind yields the name of the machine class kind used by OpenStack provider.
 func (w *workerDelegate) MachineClassKind() string {
@@ -63,7 +68,19 @@ func (w *workerDelegate) DeployMachineClasses(ctx context.Context) error {
 	if feature.UseStackitMachineControllerManager(w.cluster) {
 		chartPath = "machineclass-stackit"
 	}
-	return w.seedChartApplier.ApplyFromEmbeddedFS(ctx, charts.InternalChart, filepath.Join(charts.InternalChartsPath, chartPath), w.worker.Namespace, "machineclass", kubernetes.Values(map[string]any{"machineClasses": w.machineClasses}))
+	err := w.seedChartApplier.ApplyFromEmbeddedFS(ctx, charts.InternalChart, filepath.Join(charts.InternalChartsPath, chartPath), w.worker.Namespace, "machineclass", kubernetes.Values(map[string]any{"machineClasses": w.machineClasses}))
+	if err != nil {
+		return err
+	}
+
+	if feature.MigrateStackitMachineControllerManager(w.cluster) {
+		err = w.migrateMachines(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // GenerateMachineDeployments generates the configuration for the desired machine deployments.
@@ -405,4 +422,78 @@ func EnsureUniformMachineImages(images []stackitv1alpha1.MachineImage, definitio
 		}, definitions)
 	}
 	return uniformMachineImages
+}
+
+func (w *workerDelegate) migrateMachines(ctx context.Context) error {
+	var allMachines machinev1alpha1.MachineList
+	var migrateMachines []machinev1alpha1.Machine
+
+	err := w.seedClient.List(ctx, &allMachines, &client.ListOptions{Namespace: w.worker.Namespace})
+	if err != nil {
+		return err
+	}
+
+	for i := range allMachines.Items {
+		// ignore error as default is false
+		migrateAnnotation, _ := strconv.ParseBool(allMachines.Items[i].Annotations[shouldMigrateMachineAnnotation])
+		if !strings.HasPrefix(allMachines.Items[i].Spec.ProviderID, "stackit://") || migrateAnnotation {
+			migrateMachines = append(migrateMachines, allMachines.Items[i])
+		}
+	}
+
+	if len(migrateMachines) == 0 {
+		// no old openstack machine
+		return nil
+	}
+
+	iaas, err := w.stackitClient.IaaS(ctx, w.seedClient, w.worker.Spec.SecretRef)
+	if err != nil {
+		return err
+	}
+
+	for _, m := range migrateMachines {
+		patchAnnotations := client.MergeFrom(m.DeepCopy())
+		m.Annotations[shouldMigrateMachineAnnotation] = "true"
+		m.Annotations[migratedMachineAnnotation] = "true"
+		err = w.seedClient.Patch(ctx, &m, patchAnnotations)
+		if err != nil {
+			return err
+		}
+
+		if m.Spec.ProviderID != "" {
+			providerIDParts := strings.Split(m.Spec.ProviderID, "/")
+			if len(providerIDParts) == 0 {
+				return fmt.Errorf("migrateMachines: malformed machine provider ID: %s", m.Spec.ProviderID)
+			}
+			serverID := providerIDParts[len(providerIDParts)-1]
+
+			patch := client.MergeFrom(m.DeepCopy())
+			m.Spec.ProviderID = fmt.Sprintf("stackit://%s/%s", iaas.ProjectID(), serverID)
+			err = w.seedClient.Patch(ctx, &m, patch)
+			if err != nil {
+				return err
+			}
+
+			_, err = iaas.UpdateServer(ctx, serverID, iaas2.UpdateServerPayload{
+				Labels: map[string]any{
+					//	// TODO refine labels
+					"mcm.gardener.cloud/machine":      m.Name,
+					"mcm.gardener.cloud/machineclass": m.Spec.Class.Name,
+					"mcm.gardener.cloud/role":         "node",
+				},
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		patchRemoveMigrationAnnotation := client.MergeFrom(m.DeepCopy())
+		delete(m.Annotations, shouldMigrateMachineAnnotation)
+		err = w.seedClient.Patch(ctx, &m, patchRemoveMigrationAnnotation)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -76,9 +76,7 @@ func (w *workerDelegate) DeployMachineClasses(ctx context.Context) error {
 		return err
 	}
 
-	fmt.Println("Deploying OpenStack machine classes...")
 	if feature.MigrateStackitMachineControllerManager(w.cluster) && w.worker.Annotations[workerMigratedAnnotation] != "true" {
-		fmt.Println("Migrating Stackit Machine Controller Manager to Gardener Machine Controller Manager...") // TODO: remove later
 		err = w.migrateMachines(ctx)
 		if err != nil {
 			return err
@@ -458,6 +456,9 @@ func (w *workerDelegate) migrateMachines(ctx context.Context) error {
 
 	for _, m := range migrateMachines {
 		patchAnnotations := client.MergeFrom(m.DeepCopy())
+		if m.Annotations == nil {
+			m.Annotations = make(map[string]string)
+		}
 		m.Annotations[shouldMigrateMachineAnnotation] = "true"
 		m.Annotations[migratedMachineAnnotation] = "true"
 		err = w.seedClient.Patch(ctx, &m, patchAnnotations)

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenutils "github.com/gardener/gardener/pkg/utils"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
-	iaas2 "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
+	iaas "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -428,8 +428,13 @@ func EnsureUniformMachineImages(images []stackitv1alpha1.MachineImage, definitio
 }
 
 func (w *workerDelegate) migrateMachines(ctx context.Context) error {
-	var allMachines machinev1alpha1.MachineList
-	var migrateMachines []machinev1alpha1.Machine
+	var (
+		allMachines     machinev1alpha1.MachineList
+		migrateMachines []machinev1alpha1.Machine
+	)
+	var openStackProviderIDPattern = regexp.MustCompile(`^openstack:///[^/]+/([^/]+)$`)
+
+	const stackitProviderID = "stackit://"
 
 	err := w.seedClient.List(ctx, &allMachines, &client.ListOptions{Namespace: w.worker.Namespace})
 	if err != nil {
@@ -449,11 +454,6 @@ func (w *workerDelegate) migrateMachines(ctx context.Context) error {
 		return w.markWorkerAsMigrated(ctx)
 	}
 
-	iaas, err := w.stackitClient.IaaS(ctx, w.seedClient, w.worker.Spec.SecretRef)
-	if err != nil {
-		return err
-	}
-
 	for _, m := range migrateMachines {
 		patchAnnotations := client.MergeFrom(m.DeepCopy())
 		if m.Annotations == nil {
@@ -467,20 +467,24 @@ func (w *workerDelegate) migrateMachines(ctx context.Context) error {
 		}
 
 		if m.Spec.ProviderID != "" {
-			providerIDParts := strings.Split(m.Spec.ProviderID, "/")
-			if len(providerIDParts) == 0 {
-				return fmt.Errorf("migrateMachines: malformed machine provider ID: %s", m.Spec.ProviderID)
+			matches := openStackProviderIDPattern.FindStringSubmatch(m.Spec.ProviderID)
+			if len(matches) != 2 {
+				return fmt.Errorf(
+					"migrateMachines: malformed machine provider ID: %s",
+					m.Spec.ProviderID,
+				)
 			}
-			serverID := providerIDParts[len(providerIDParts)-1]
+			// capture server ID from provider ID
+			serverID := matches[1]
 
 			patch := client.MergeFrom(m.DeepCopy())
-			m.Spec.ProviderID = fmt.Sprintf("stackit://%s/%s", iaas.ProjectID(), serverID)
+			m.Spec.ProviderID = fmt.Sprintf("%s%s/%s", stackitProviderID, w.iaaSClient.ProjectID(), serverID)
 			err = w.seedClient.Patch(ctx, &m, patch)
 			if err != nil {
 				return err
 			}
 
-			_, err = iaas.UpdateServer(ctx, serverID, iaas2.UpdateServerPayload{
+			_, err = w.iaaSClient.UpdateServer(ctx, serverID, iaas.UpdateServerPayload{
 				Labels: map[string]any{
 					//	// TODO refine labels
 					"mcm.gardener.cloud/machine":      m.Name,

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -7,6 +7,7 @@ package worker
 import (
 	"context"
 	"fmt"
+	"log"
 	"math"
 	"path/filepath"
 	"regexp"
@@ -501,7 +502,28 @@ func (w *workerDelegate) migrateMachines(ctx context.Context) error {
 	return w.markWorkerAsMigrated(ctx)
 }
 
+//func (w *workerDelegate) markWorkerAsMigrated(ctx context.Context) error {
+//	patchWorker := client.MergeFrom(w.worker.DeepCopy())
+//
+//	if w.worker.Annotations == nil {
+//		w.worker.Annotations = make(map[string]string)
+//	}
+//
+//	w.worker.Annotations[workerMigratedAnnotation] = "true"
+//
+//	return w.seedClient.Patch(ctx, w.worker, patchWorker)
+//}
+
+// this is a diagnosis code and should not be used in production code.
 func (w *workerDelegate) markWorkerAsMigrated(ctx context.Context) error {
+	log.Printf(
+		"markWorkerAsMigrated: worker=%s namespace=%s resourceVersion=%s annotationsBefore=%v",
+		w.worker.Name,
+		w.worker.Namespace,
+		w.worker.ResourceVersion,
+		w.worker.Annotations,
+	)
+
 	patchWorker := client.MergeFrom(w.worker.DeepCopy())
 
 	if w.worker.Annotations == nil {
@@ -510,5 +532,61 @@ func (w *workerDelegate) markWorkerAsMigrated(ctx context.Context) error {
 
 	w.worker.Annotations[workerMigratedAnnotation] = "true"
 
-	return w.seedClient.Patch(ctx, w.worker, patchWorker)
+	log.Printf(
+		"markWorkerAsMigrated: patching worker=%s annotation=%s value=%s",
+		w.worker.Name,
+		workerMigratedAnnotation,
+		w.worker.Annotations[workerMigratedAnnotation],
+	)
+
+	if err := w.seedClient.Patch(ctx, w.worker, patchWorker); err != nil {
+		log.Printf(
+			"markWorkerAsMigrated: PATCH FAILED worker=%s error=%v",
+			w.worker.Name,
+			err,
+		)
+		return fmt.Errorf("patch worker migration annotation: %w", err)
+	}
+
+	log.Printf(
+		"markWorkerAsMigrated: PATCH SUCCEEDED worker=%s resourceVersion=%s annotations=%v",
+		w.worker.Name,
+		w.worker.ResourceVersion,
+		w.worker.Annotations,
+	)
+
+	// Read the Worker again from the API server.
+	var worker extensionsv1alpha1.Worker
+	if err := w.seedClient.Get(
+		ctx,
+		client.ObjectKeyFromObject(w.worker),
+		&worker,
+	); err != nil {
+		log.Printf(
+			"markWorkerAsMigrated: GET AFTER PATCH FAILED worker=%s error=%v",
+			w.worker.Name,
+			err,
+		)
+		return fmt.Errorf("get worker after migration patch: %w", err)
+	}
+
+	actualValue := worker.Annotations[workerMigratedAnnotation]
+
+	log.Printf(
+		"markWorkerAsMigrated: API SERVER VALUE worker=%s annotation=%s value=%q allAnnotations=%v",
+		worker.Name,
+		workerMigratedAnnotation,
+		actualValue,
+		worker.Annotations,
+	)
+
+	if actualValue != "true" {
+		return fmt.Errorf(
+			"worker migration annotation was not persisted: worker=%s value=%q",
+			worker.Name,
+			actualValue,
+		)
+	}
+
+	return nil
 }

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -42,6 +42,8 @@ const (
 	shouldMigrateMachineAnnotation = "stackit.cloud/machine-should-be-migrated"
 	migratedMachineAnnotation      = "stackit.cloud/migrated-machine"
 	workerMigratedAnnotation       = "stackit.cloud/machine-controller-manager-migrated"
+
+	stackitProviderID = "stackit://"
 )
 
 // MachineClassKind yields the name of the machine class kind used by OpenStack provider.
@@ -432,12 +434,6 @@ func (w *workerDelegate) migrateMachines(ctx context.Context) error {
 		allMachines     machinev1alpha1.MachineList
 		migrateMachines []machinev1alpha1.Machine
 	)
-	var (
-		openStackProviderIDPattern = regexp.MustCompile(`^openstack:///[^/]+/([^/]+)$`)
-		stackitProviderIDPattern   = regexp.MustCompile(`^stackit://[^/]+/([^/]+)$`)
-	)
-
-	const stackitProviderID = "stackit://"
 
 	err := w.seedClient.List(ctx, &allMachines, &client.ListOptions{Namespace: w.worker.Namespace})
 	if err != nil {
@@ -470,20 +466,10 @@ func (w *workerDelegate) migrateMachines(ctx context.Context) error {
 		}
 
 		if m.Spec.ProviderID != "" {
-			matches := openStackProviderIDPattern.FindStringSubmatch(m.Spec.ProviderID)
-			if len(matches) != 2 {
-				// A retry can resume, after the provider ID was already converted but
-				// before updating the server labels completed.
-				matches = stackitProviderIDPattern.FindStringSubmatch(m.Spec.ProviderID)
+			serverID, err := serverIDFromProviderID(m.Spec.ProviderID)
+			if err != nil {
+				return fmt.Errorf("migrateMachines: %w", err)
 			}
-			if len(matches) != 2 {
-				return fmt.Errorf(
-					"migrateMachines: malformed machine provider ID: %s",
-					m.Spec.ProviderID,
-				)
-			}
-			// capture server ID from provider ID
-			serverID := matches[1]
 
 			patch := client.MergeFrom(m.DeepCopy())
 			m.Spec.ProviderID = fmt.Sprintf("%s%s/%s", stackitProviderID, w.iaaSClient.ProjectID(), serverID)
@@ -494,7 +480,7 @@ func (w *workerDelegate) migrateMachines(ctx context.Context) error {
 
 			_, err = w.iaaSClient.UpdateServer(ctx, serverID, iaas.UpdateServerPayload{
 				Labels: map[string]any{
-					//	// TODO refine labels
+					// TODO refine labels
 					"mcm.gardener.cloud/machine":      m.Name,
 					"mcm.gardener.cloud/machineclass": m.Spec.Class.Name,
 					"mcm.gardener.cloud/role":         "node",
@@ -526,4 +512,20 @@ func (w *workerDelegate) markWorkerAsMigrated(ctx context.Context) error {
 	w.worker.Annotations[workerMigratedAnnotation] = "true"
 
 	return w.seedClient.Patch(ctx, w.worker, patchWorker)
+}
+
+func serverIDFromProviderID(providerID string) (string, error) {
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`^openstack:///[^/]+/([^/]+)$`),
+		regexp.MustCompile(`^stackit://[^/]+/([^/]+)$`),
+	}
+
+	for _, pattern := range patterns {
+		matches := pattern.FindStringSubmatch(providerID)
+		if len(matches) == 2 {
+			return matches[1], nil
+		}
+	}
+
+	return "", fmt.Errorf("malformed machine provider ID: %s", providerID)
 }

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -514,13 +514,19 @@ func (w *workerDelegate) markWorkerAsMigrated(ctx context.Context) error {
 	return w.seedClient.Patch(ctx, w.worker, patchWorker)
 }
 
-func serverIDFromProviderID(providerID string) (string, error) {
-	patterns := []*regexp.Regexp{
+var (
+	providerIDPatterns []*regexp.Regexp
+)
+
+func init() {
+	providerIDPatterns = []*regexp.Regexp{
 		regexp.MustCompile(`^openstack:///[^/]+/(?P<serverID>[^/]+)$`),
 		regexp.MustCompile(`^stackit://[^/]+/(?P<serverID>[^/]+)$`),
 	}
+}
 
-	for _, pattern := range patterns {
+func serverIDFromProviderID(providerID string) (string, error) {
+	for _, pattern := range providerIDPatterns {
 		match := pattern.FindStringSubmatch(providerID)
 		if len(match) == 0 {
 			continue

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenutils "github.com/gardener/gardener/pkg/utils"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	iaas2 "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -35,7 +36,6 @@ import (
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/openstack"
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit"
 	stackitutils "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/utils"
-	iaas2 "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
 )
 
 const (

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -38,9 +38,11 @@ import (
 	iaas2 "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
 )
 
-const shouldMigrateMachineAnnotation = "stackit.cloud/machine-should-be-migrated"
-const migratedMachineAnnotation = "stackit.cloud/migrated-machine"
-const workerMigratedAnnotation = "stackit.cloud/machine-controller-manager-migrated"
+const (
+	shouldMigrateMachineAnnotation = "stackit.cloud/machine-should-be-migrated"
+	migratedMachineAnnotation      = "stackit.cloud/migrated-machine"
+	workerMigratedAnnotation       = "stackit.cloud/machine-controller-manager-migrated"
+)
 
 // MachineClassKind yields the name of the machine class kind used by OpenStack provider.
 func (w *workerDelegate) MachineClassKind() string {
@@ -444,7 +446,7 @@ func (w *workerDelegate) migrateMachines(ctx context.Context) error {
 
 	if len(migrateMachines) == 0 {
 		// no old openstack machine
-		return nil
+		return w.markWorkerAsMigrated(ctx)
 	}
 
 	iaas, err := w.stackitClient.IaaS(ctx, w.seedClient, w.worker.Spec.SecretRef)

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -432,7 +432,10 @@ func (w *workerDelegate) migrateMachines(ctx context.Context) error {
 		allMachines     machinev1alpha1.MachineList
 		migrateMachines []machinev1alpha1.Machine
 	)
-	var openStackProviderIDPattern = regexp.MustCompile(`^openstack:///[^/]+/([^/]+)$`)
+	var (
+		openStackProviderIDPattern = regexp.MustCompile(`^openstack:///[^/]+/([^/]+)$`)
+		stackitProviderIDPattern   = regexp.MustCompile(`^stackit://[^/]+/([^/]+)$`)
+	)
 
 	const stackitProviderID = "stackit://"
 
@@ -468,6 +471,11 @@ func (w *workerDelegate) migrateMachines(ctx context.Context) error {
 
 		if m.Spec.ProviderID != "" {
 			matches := openStackProviderIDPattern.FindStringSubmatch(m.Spec.ProviderID)
+			if len(matches) != 2 {
+				// A retry can resume, after the provider ID was already converted but
+				// before updating the server labels completed.
+				matches = stackitProviderIDPattern.FindStringSubmatch(m.Spec.ProviderID)
+			}
 			if len(matches) != 2 {
 				return fmt.Errorf(
 					"migrateMachines: malformed machine provider ID: %s",

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -7,7 +7,6 @@ package worker
 import (
 	"context"
 	"fmt"
-	"log"
 	"math"
 	"path/filepath"
 	"regexp"
@@ -502,28 +501,7 @@ func (w *workerDelegate) migrateMachines(ctx context.Context) error {
 	return w.markWorkerAsMigrated(ctx)
 }
 
-//func (w *workerDelegate) markWorkerAsMigrated(ctx context.Context) error {
-//	patchWorker := client.MergeFrom(w.worker.DeepCopy())
-//
-//	if w.worker.Annotations == nil {
-//		w.worker.Annotations = make(map[string]string)
-//	}
-//
-//	w.worker.Annotations[workerMigratedAnnotation] = "true"
-//
-//	return w.seedClient.Patch(ctx, w.worker, patchWorker)
-//}
-
-// this is a diagnosis code and should not be used in production code.
 func (w *workerDelegate) markWorkerAsMigrated(ctx context.Context) error {
-	log.Printf(
-		"markWorkerAsMigrated: worker=%s namespace=%s resourceVersion=%s annotationsBefore=%v",
-		w.worker.Name,
-		w.worker.Namespace,
-		w.worker.ResourceVersion,
-		w.worker.Annotations,
-	)
-
 	patchWorker := client.MergeFrom(w.worker.DeepCopy())
 
 	if w.worker.Annotations == nil {
@@ -532,61 +510,5 @@ func (w *workerDelegate) markWorkerAsMigrated(ctx context.Context) error {
 
 	w.worker.Annotations[workerMigratedAnnotation] = "true"
 
-	log.Printf(
-		"markWorkerAsMigrated: patching worker=%s annotation=%s value=%s",
-		w.worker.Name,
-		workerMigratedAnnotation,
-		w.worker.Annotations[workerMigratedAnnotation],
-	)
-
-	if err := w.seedClient.Patch(ctx, w.worker, patchWorker); err != nil {
-		log.Printf(
-			"markWorkerAsMigrated: PATCH FAILED worker=%s error=%v",
-			w.worker.Name,
-			err,
-		)
-		return fmt.Errorf("patch worker migration annotation: %w", err)
-	}
-
-	log.Printf(
-		"markWorkerAsMigrated: PATCH SUCCEEDED worker=%s resourceVersion=%s annotations=%v",
-		w.worker.Name,
-		w.worker.ResourceVersion,
-		w.worker.Annotations,
-	)
-
-	// Read the Worker again from the API server.
-	var worker extensionsv1alpha1.Worker
-	if err := w.seedClient.Get(
-		ctx,
-		client.ObjectKeyFromObject(w.worker),
-		&worker,
-	); err != nil {
-		log.Printf(
-			"markWorkerAsMigrated: GET AFTER PATCH FAILED worker=%s error=%v",
-			w.worker.Name,
-			err,
-		)
-		return fmt.Errorf("get worker after migration patch: %w", err)
-	}
-
-	actualValue := worker.Annotations[workerMigratedAnnotation]
-
-	log.Printf(
-		"markWorkerAsMigrated: API SERVER VALUE worker=%s annotation=%s value=%q allAnnotations=%v",
-		worker.Name,
-		workerMigratedAnnotation,
-		actualValue,
-		worker.Annotations,
-	)
-
-	if actualValue != "true" {
-		return fmt.Errorf(
-			"worker migration annotation was not persisted: worker=%s value=%q",
-			worker.Name,
-			actualValue,
-		)
-	}
-
-	return nil
+	return w.seedClient.Patch(ctx, w.worker, patchWorker)
 }

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -984,6 +984,9 @@ var _ = Describe("Machines", func() {
 
 					mockIaaSClient = mockstackitclient.NewMockIaaSClient(ctrl)
 
+					if cluster.Shoot.Annotations == nil {
+						cluster.Shoot.Annotations = map[string]string{}
+					}
 					cluster.Shoot.Annotations[feature.ShootMigrateSTACKITMachineControllerManager] = "true"
 					workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain, mockIaaSClient)
 

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Machines", func() {
 	Context("workerDelegate", func() {
 
 		BeforeEach(func() {
-			workerDelegate, _ = NewWorkerDelegate(nil, scheme, nil, "", nil, nil, "")
+			workerDelegate, _ = NewWorkerDelegate(nil, scheme, nil, "", nil, nil, "", nil)
 		})
 
 		Describe("#TestLabelNormalization", func() {
@@ -572,7 +572,7 @@ var _ = Describe("Machines", func() {
 					WithStatusSubresource(&extensionsv1alpha1.Worker{}).
 					Build()
 
-				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, clusterWithoutImages, customLabelDomain)
+				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, clusterWithoutImages, customLabelDomain, nil)
 			})
 
 			Describe("machine images", func() {
@@ -842,7 +842,7 @@ var _ = Describe("Machines", func() {
 				})
 
 				It("should return the expected machine deployments for profile image types", func() {
-					workerDelegate, _ := NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain)
+					workerDelegate, _ := NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain, nil)
 
 					// Test workerDelegate.DeployMachineClasses()
 
@@ -881,7 +881,7 @@ var _ = Describe("Machines", func() {
 
 				It("should return the expected machine deployments for profile image types with id", func() {
 					// setup(region, "", machineImageID, archARM)
-					workerDelegate, _ := NewWorkerDelegate(c, scheme, chartApplier, "", workerWithRegion, clusterWithRegion, customLabelDomain)
+					workerDelegate, _ := NewWorkerDelegate(c, scheme, chartApplier, "", workerWithRegion, clusterWithRegion, customLabelDomain, nil)
 					clusterWithRegion.Shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{Enabled: new(true)}
 
 					// Test workerDelegate.DeployMachineClasses()
@@ -924,7 +924,7 @@ var _ = Describe("Machines", func() {
 							w.Spec.Pools[0].ProviderConfig = &runtime.RawExtension{
 								Raw: encode(workerConfig),
 							}
-							workerDelegate, _ := NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain)
+							workerDelegate, _ := NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain, nil)
 
 							result, err := workerDelegate.GenerateMachineDeployments(ctx)
 							Expect(err).NotTo(HaveOccurred())
@@ -974,7 +974,7 @@ var _ = Describe("Machines", func() {
 			It("should fail because the infrastructure status cannot be decoded", func() {
 				w.Spec.InfrastructureProviderStatus = &runtime.RawExtension{}
 
-				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain)
+				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain, nil)
 
 				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				Expect(err).To(HaveOccurred())
@@ -986,7 +986,7 @@ var _ = Describe("Machines", func() {
 					Raw: encode(&stackitv1alpha1.InfrastructureStatus{}),
 				}
 
-				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain)
+				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain, nil)
 
 				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				Expect(err).To(HaveOccurred())
@@ -996,7 +996,7 @@ var _ = Describe("Machines", func() {
 			It("should fail because the machine image for this cloud profile cannot be found", func() {
 				clusterWithoutImages.CloudProfile.Name = "another-cloud-profile"
 
-				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, clusterWithoutImages, customLabelDomain)
+				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, clusterWithoutImages, customLabelDomain, nil)
 
 				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				Expect(err).To(HaveOccurred())
@@ -1017,7 +1017,7 @@ var _ = Describe("Machines", func() {
 					NodeConditions:         testNodeConditions,
 				}
 
-				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain)
+				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain, nil)
 
 				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				resultSettings := result[0].MachineConfiguration
@@ -1040,7 +1040,7 @@ var _ = Describe("Machines", func() {
 					ScaleDownUtilizationThreshold:    new("0.5"),
 				}
 				w.Spec.Pools[1].ClusterAutoscaler = nil
-				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain)
+				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain, nil)
 
 				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				Expect(err).NotTo(HaveOccurred())
@@ -1108,7 +1108,7 @@ var _ = Describe("Machines", func() {
 				w.Spec.Pools[0].MachineControllerManagerSettings = &gardencorev1beta1.MachineControllerManagerSettings{
 					AutoPreserveFailedMachineMax: new(int32(4)),
 				}
-				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain)
+				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain, nil)
 
 				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				Expect(err).NotTo(HaveOccurred())
@@ -1119,7 +1119,7 @@ var _ = Describe("Machines", func() {
 
 			It("should set autoPreserveFailedMachineMax to 0 per zone when machineControllerManagerSettings is nil", func() {
 				w.Spec.Pools[0].MachineControllerManagerSettings = nil
-				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain)
+				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain, nil)
 
 				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				Expect(err).NotTo(HaveOccurred())
@@ -1132,7 +1132,7 @@ var _ = Describe("Machines", func() {
 				w.Spec.Pools[0].MachineControllerManagerSettings = &gardencorev1beta1.MachineControllerManagerSettings{
 					AutoPreserveFailedMachineMax: nil,
 				}
-				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain)
+				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain, nil)
 
 				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				Expect(err).NotTo(HaveOccurred())

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Machines", func() {
 		c            client.Client
 		chartApplier *mockkubernetes.MockChartApplier
 
-		mockStackitClient *mockstackitclient.MockFactory
+		mockIaaSClient *mockstackitclient.MockIaaSClient
 
 		workerDelegate genericworkeractuator.WorkerDelegate
 		scheme         *runtime.Scheme
@@ -982,13 +982,10 @@ var _ = Describe("Machines", func() {
 				BeforeEach(func() {
 					DeferCleanup(testutils.WithFeatureGate(feature.MutableGate, feature.UseSTACKITMachineControllerManager, true))
 
-					mockStackitClient = mockstackitclient.NewMockFactory(ctrl)
-					if cluster.Shoot.Annotations == nil {
-						cluster.Shoot.Annotations = map[string]string{}
-					}
+					mockIaaSClient = mockstackitclient.NewMockIaaSClient(ctrl)
 
 					cluster.Shoot.Annotations[feature.ShootMigrateSTACKITMachineControllerManager] = "true"
-					workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain, mockStackitClient)
+					workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain, mockIaaSClient)
 
 					machine = &machinev1alpha1.Machine{
 						ObjectMeta: metav1.ObjectMeta{
@@ -1019,12 +1016,6 @@ var _ = Describe("Machines", func() {
 				})
 
 				It("should migrate the machine controller manager", func() {
-					mockIaaSClient := mockstackitclient.NewMockIaaSClient(ctrl)
-
-					mockStackitClient.EXPECT().
-						IaaS(ctx, c, w.Spec.SecretRef).
-						Return(mockIaaSClient, nil)
-
 					mockIaaSClient.EXPECT().
 						ProjectID().
 						Return("project-id-123")
@@ -1094,12 +1085,8 @@ var _ = Describe("Machines", func() {
 					}
 					Expect(c.Create(ctx, pendingMachine)).To(Succeed())
 
-					failingIaaSClient := mockstackitclient.NewMockIaaSClient(ctrl)
-					mockStackitClient.EXPECT().
-						IaaS(ctx, c, w.Spec.SecretRef).
-						Return(failingIaaSClient, nil)
-					failingIaaSClient.EXPECT().ProjectID().Return("project-id-123")
-					failingIaaSClient.EXPECT().
+					mockIaaSClient.EXPECT().ProjectID().Return("project-id-123")
+					mockIaaSClient.EXPECT().
 						UpdateServer(ctx, "server-456", iaas2.UpdateServerPayload{
 							Labels: map[string]any{
 								"mcm.gardener.cloud/machine":      pendingMachine.Name,
@@ -1119,12 +1106,8 @@ var _ = Describe("Machines", func() {
 					Expect(c.Get(ctx, client.ObjectKey{Name: machine.Name, Namespace: machine.Namespace}, unchangedMigratedMachine)).To(Succeed())
 					Expect(unchangedMigratedMachine).To(Equal(expectedMigratedMachine))
 
-					retryIaaSClient := mockstackitclient.NewMockIaaSClient(ctrl)
-					mockStackitClient.EXPECT().
-						IaaS(ctx, c, w.Spec.SecretRef).
-						Return(retryIaaSClient, nil)
-					retryIaaSClient.EXPECT().ProjectID().Return("project-id-123")
-					retryIaaSClient.EXPECT().
+					mockIaaSClient.EXPECT().ProjectID().Return("project-id-123")
+					mockIaaSClient.EXPECT().
 						UpdateServer(ctx, "server-456", iaas2.UpdateServerPayload{
 							Labels: map[string]any{
 								"mcm.gardener.cloud/machine":      pendingMachine.Name,

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -1249,7 +1249,7 @@ var _ = Describe("Machines", func() {
 			})
 			DescribeTable("customLabelDomain in machineclass helm chart",
 				func(customDomain string) {
-					workerDelegate, _ := NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customDomain)
+					workerDelegate, _ := NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customDomain, nil)
 
 					machineClassPath := filepath.Join("internal", "machineclass")
 					if useStackitMCM {

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -27,6 +27,7 @@ import (
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	iaas2 "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -41,6 +42,7 @@ import (
 	. "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/controller/worker"
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/feature"
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/openstack"
+	mockstackitclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit/client/mock"
 )
 
 var _ = Describe("Machines", func() {
@@ -50,6 +52,8 @@ var _ = Describe("Machines", func() {
 		ctrl         *gomock.Controller
 		c            client.Client
 		chartApplier *mockkubernetes.MockChartApplier
+
+		mockStackitClient *mockstackitclient.MockFactory
 
 		workerDelegate genericworkeractuator.WorkerDelegate
 		scheme         *runtime.Scheme
@@ -906,6 +910,97 @@ var _ = Describe("Machines", func() {
 					result, err := workerDelegate.GenerateMachineDeployments(ctx)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(Equal(machineDeployments))
+				})
+
+				Context("MCM migration", func() {
+					BeforeEach(func() {
+						DeferCleanup(testutils.WithFeatureGate(feature.MutableGate, feature.UseSTACKITMachineControllerManager, useStackitMCM))
+						//DeferCleanup(testutils.WithFeatureGate(feature.MutableGate, feature.MigrateSTACKITMachineControllerManager, true))
+						mockStackitClient = mockstackitclient.NewMockFactory(ctrl)
+						workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain, mockStackitClient)
+					})
+
+					It("should migrate the machine controller manager", func() {
+						By("creating a machine")
+						machine := &machinev1alpha1.Machine{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "machine-1",
+								Namespace: w.Namespace,
+							},
+							Spec: machinev1alpha1.MachineSpec{
+								Class: machinev1alpha1.ClassSpec{
+									Name: "machineclass",
+								},
+								ProviderID: "openstack:///RegionOne/server-123",
+							},
+						}
+
+						Expect(c.Create(ctx, machine)).To(Succeed())
+
+						By("creating a machine class")
+						machineClassPath := filepath.Join("internal", "machineclass")
+						if useStackitMCM {
+							machineClassPath = filepath.Join("internal", "machineclass-stackit")
+						}
+
+						chartApplier.
+							EXPECT().
+							ApplyFromEmbeddedFS(
+								ctx,
+								charts.InternalChart,
+								machineClassPath,
+								w.Namespace,
+								"machineclass",
+								kubernetes.Values(machineClasses),
+							).
+							Return(nil)
+
+						Expect(workerDelegate.DeployMachineClasses(ctx)).To(Succeed())
+
+						By("enabling the feature gate")
+						DeferCleanup(testutils.WithFeatureGate(feature.MutableGate, feature.UseSTACKITMachineControllerManager, true))
+						DeferCleanup(testutils.WithFeatureGate(feature.MutableGate, feature.MigrateSTACKITMachineControllerManager, true))
+
+						mockstackitclient.NewMockIaaSClient(ctrl).EXPECT().UpdateServer(ctx, "server-123", iaas2.UpdateServerPayload{
+							Labels: map[string]any{
+								"mcm.gardener.cloud/machine":      machine.Name,
+								"mcm.gardener.cloud/machineclass": machine.Spec.Class.Name,
+								"mcm.gardener.cloud/role":         "node",
+							},
+						}).Return(nil, nil)
+
+						By("checking for the migrated machine")
+						migratedMachine := &machinev1alpha1.Machine{}
+
+						Expect(c.Get(ctx, client.ObjectKey{
+							Name:      "machine-1",
+							Namespace: w.Namespace,
+						}, migratedMachine)).To(Succeed())
+
+						Expect(migratedMachine.Spec.ProviderID).
+							To(Equal("stackit://project-id-123/server-123"))
+
+						Expect(migratedMachine.Annotations).
+							To(HaveKeyWithValue("stackit.cloud/migrated-machine", "true"))
+
+						// TODO: how do i check this, as the annotation will get removed soon after the migration
+						//Expect(migratedMachine.Annotations).
+						//	NotTo(HaveKey("stackit.cloud/machine-should-be-migrated"))
+
+						By("checking for the worker")
+						migratedWorker := &extensionsv1alpha1.Worker{}
+
+						Expect(c.Get(ctx, client.ObjectKey{
+							Name:      w.Name,
+							Namespace: w.Namespace,
+						}, migratedWorker)).To(Succeed())
+
+						Expect(migratedWorker.Annotations).
+							To(HaveKeyWithValue(
+								"stackit.cloud/machine-controller-manager-migrated",
+								"true",
+							))
+					})
 				})
 
 				Context("Machine Labels", func() {

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -1335,7 +1335,7 @@ var _ = Describe("Machines", func() {
 					machineClassPath = filepath.Join("internal", "machineclass-stackit")
 				}
 
-				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, clusterWithPremiumMachineType, customLabelDomain)
+				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, clusterWithPremiumMachineType, customLabelDomain, nil)
 
 				var capturedMachineClasses []map[string]any
 				chartApplier.

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -561,6 +561,7 @@ var _ = Describe("Machines", func() {
 				fakeScheme := runtime.NewScheme()
 				Expect(corev1.AddToScheme(fakeScheme)).To(Succeed())
 				Expect(extensionsv1alpha1.AddToScheme(fakeScheme)).To(Succeed())
+				Expect(machinev1alpha1.AddToScheme(fakeScheme)).To(Succeed())
 				c = fakeclient.NewClientBuilder().
 					WithScheme(fakeScheme).
 					WithObjects(
@@ -961,13 +962,33 @@ var _ = Describe("Machines", func() {
 						DeferCleanup(testutils.WithFeatureGate(feature.MutableGate, feature.UseSTACKITMachineControllerManager, true))
 						DeferCleanup(testutils.WithFeatureGate(feature.MutableGate, feature.MigrateSTACKITMachineControllerManager, true))
 
-						mockstackitclient.NewMockIaaSClient(ctrl).EXPECT().UpdateServer(ctx, "server-123", iaas2.UpdateServerPayload{
-							Labels: map[string]any{
-								"mcm.gardener.cloud/machine":      machine.Name,
-								"mcm.gardener.cloud/machineclass": machine.Spec.Class.Name,
-								"mcm.gardener.cloud/role":         "node",
-							},
-						}).Return(nil, nil)
+						//mockstackitclient.NewMockIaaSClient(ctrl).EXPECT().UpdateServer(ctx, "server-123", iaas2.UpdateServerPayload{
+						//	Labels: map[string]any{
+						//		"mcm.gardener.cloud/machine":      machine.Name,
+						//		"mcm.gardener.cloud/machineclass": machine.Spec.Class.Name,
+						//		"mcm.gardener.cloud/role":         "node",
+						//	},
+						//}).Return(nil, nil)
+
+						mockIaaSClient := mockstackitclient.NewMockIaaSClient(ctrl)
+
+						mockStackitClient.EXPECT().
+							IaaS(ctx, c, w.Spec.SecretRef).
+							Return(mockIaaSClient, nil)
+
+						mockIaaSClient.EXPECT().
+							ProjectID().
+							Return("project-id-123")
+
+						mockIaaSClient.EXPECT().
+							UpdateServer(ctx, "server-123", iaas2.UpdateServerPayload{
+								Labels: map[string]any{
+									"mcm.gardener.cloud/machine":      machine.Name,
+									"mcm.gardener.cloud/machineclass": machine.Spec.Class.Name,
+									"mcm.gardener.cloud/role":         "node",
+								},
+							}).
+							Return(nil, nil)
 
 						By("checking for the migrated machine")
 						migratedMachine := &machinev1alpha1.Machine{}

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -913,117 +913,6 @@ var _ = Describe("Machines", func() {
 					Expect(result).To(Equal(machineDeployments))
 				})
 
-				Context("MCM migration", func() {
-					BeforeEach(func() {
-						DeferCleanup(testutils.WithFeatureGate(feature.MutableGate, feature.UseSTACKITMachineControllerManager, useStackitMCM))
-						//DeferCleanup(testutils.WithFeatureGate(feature.MutableGate, feature.MigrateSTACKITMachineControllerManager, true))
-						mockStackitClient = mockstackitclient.NewMockFactory(ctrl)
-						workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain, mockStackitClient)
-					})
-
-					It("should migrate the machine controller manager", func() {
-						By("creating a machine")
-						machine := &machinev1alpha1.Machine{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      "machine-1",
-								Namespace: w.Namespace,
-							},
-							Spec: machinev1alpha1.MachineSpec{
-								Class: machinev1alpha1.ClassSpec{
-									Name: "machineclass",
-								},
-								ProviderID: "openstack:///RegionOne/server-123",
-							},
-						}
-
-						Expect(c.Create(ctx, machine)).To(Succeed())
-
-						By("creating a machine class")
-						machineClassPath := filepath.Join("internal", "machineclass")
-						if useStackitMCM {
-							machineClassPath = filepath.Join("internal", "machineclass-stackit")
-						}
-
-						chartApplier.
-							EXPECT().
-							ApplyFromEmbeddedFS(
-								ctx,
-								charts.InternalChart,
-								machineClassPath,
-								w.Namespace,
-								"machineclass",
-								kubernetes.Values(machineClasses),
-							).
-							Return(nil)
-
-						Expect(workerDelegate.DeployMachineClasses(ctx)).To(Succeed())
-
-						By("enabling the feature gate")
-						DeferCleanup(testutils.WithFeatureGate(feature.MutableGate, feature.UseSTACKITMachineControllerManager, true))
-						DeferCleanup(testutils.WithFeatureGate(feature.MutableGate, feature.MigrateSTACKITMachineControllerManager, true))
-
-						//mockstackitclient.NewMockIaaSClient(ctrl).EXPECT().UpdateServer(ctx, "server-123", iaas2.UpdateServerPayload{
-						//	Labels: map[string]any{
-						//		"mcm.gardener.cloud/machine":      machine.Name,
-						//		"mcm.gardener.cloud/machineclass": machine.Spec.Class.Name,
-						//		"mcm.gardener.cloud/role":         "node",
-						//	},
-						//}).Return(nil, nil)
-
-						mockIaaSClient := mockstackitclient.NewMockIaaSClient(ctrl)
-
-						mockStackitClient.EXPECT().
-							IaaS(ctx, c, w.Spec.SecretRef).
-							Return(mockIaaSClient, nil)
-
-						mockIaaSClient.EXPECT().
-							ProjectID().
-							Return("project-id-123")
-
-						mockIaaSClient.EXPECT().
-							UpdateServer(ctx, "server-123", iaas2.UpdateServerPayload{
-								Labels: map[string]any{
-									"mcm.gardener.cloud/machine":      machine.Name,
-									"mcm.gardener.cloud/machineclass": machine.Spec.Class.Name,
-									"mcm.gardener.cloud/role":         "node",
-								},
-							}).
-							Return(nil, nil)
-
-						By("checking for the migrated machine")
-						migratedMachine := &machinev1alpha1.Machine{}
-
-						Expect(c.Get(ctx, client.ObjectKey{
-							Name:      "machine-1",
-							Namespace: w.Namespace,
-						}, migratedMachine)).To(Succeed())
-
-						Expect(migratedMachine.Spec.ProviderID).
-							To(Equal("stackit://project-id-123/server-123"))
-
-						Expect(migratedMachine.Annotations).
-							To(HaveKeyWithValue("stackit.cloud/migrated-machine", "true"))
-
-						// TODO: how do i check this, as the annotation will get removed soon after the migration
-						//Expect(migratedMachine.Annotations).
-						//	NotTo(HaveKey("stackit.cloud/machine-should-be-migrated"))
-
-						By("checking for the worker")
-						migratedWorker := &extensionsv1alpha1.Worker{}
-
-						Expect(c.Get(ctx, client.ObjectKey{
-							Name:      w.Name,
-							Namespace: w.Namespace,
-						}, migratedWorker)).To(Succeed())
-
-						Expect(migratedWorker.Annotations).
-							To(HaveKeyWithValue(
-								"stackit.cloud/machine-controller-manager-migrated",
-								"true",
-							))
-					})
-				})
-
 				Context("Machine Labels", func() {
 					It("should consider rolling machine labels for the worker pool hash", func() {
 						// setup(region, machineImage, "")
@@ -1084,6 +973,182 @@ var _ = Describe("Machines", func() {
 						Expect(className2).NotTo(Equal(className3))
 						Expect(className3).NotTo(Equal(className4))
 					})
+				})
+			})
+
+			Context("MCM migration", func() {
+				var (
+					defaultMachineClass map[string]any
+					machineClasses      map[string]any
+				)
+
+				BeforeEach(func() {
+					defaultMachineClass = map[string]any{
+						"region":          region,
+						"keyName":         keyName,
+						"networkID":       networkID,
+						"podNetworkCIDRs": []string{podCIDR},
+						"securityGroups":  []string{securityGroupName},
+						"tags": map[string]string{
+							fmt.Sprintf("kubernetes.io-cluster-%s", technicalID): "1",
+							"kubernetes.io-role-node":                            "1",
+						},
+						"secret": map[string]any{
+							"cloudConfig": string(userData),
+						},
+						"operatingSystem": map[string]any{
+							"operatingSystemName":    machineImageName,
+							"operatingSystemVersion": strings.ReplaceAll(machineImageVersion, "+", "_"),
+						},
+					}
+
+					if useStackitMCM {
+						securityGroupID := "sg-12345"
+						// STACKIT uses security group IDs and simplified tags
+						defaultMachineClass["securityGroups"] = []string{securityGroupID}
+						defaultMachineClass["tags"] = map[string]string{
+							"kubernetes.io/cluster": technicalID,
+						}
+						// Note: subnetID is NOT included for STACKIT
+					} else {
+						// OpenStack uses security group names, full tags, and subnetID
+						defaultMachineClass["securityGroups"] = []string{securityGroupName}
+						defaultMachineClass["tags"] = map[string]string{
+							fmt.Sprintf("kubernetes.io-cluster-%s", technicalID): "1",
+							"kubernetes.io-role-node":                            "1",
+						}
+						defaultMachineClass["subnetID"] = subnetID
+					}
+
+					var (
+						machineClassPool1Zone1 = addKeyValueToMap(defaultMachineClass, "availabilityZone", zone1)
+						machineClassPool1Zone2 = addKeyValueToMap(defaultMachineClass, "availabilityZone", zone2)
+						machineClassPool2Zone1 = addKeyValueToMap(defaultMachineClass, "availabilityZone", zone1)
+						machineClassPool2Zone2 = addKeyValueToMap(defaultMachineClass, "availabilityZone", zone2)
+						machineClassPool3Zone1 = addKeyValueToMap(defaultMachineClass, "availabilityZone", zone1)
+						machineClassPool3Zone2 = addKeyValueToMap(defaultMachineClass, "availabilityZone", zone2)
+					)
+
+					machineClasses = map[string]any{"machineClasses": []map[string]any{
+						machineClassPool1Zone1,
+						machineClassPool1Zone2,
+						machineClassPool2Zone1,
+						machineClassPool2Zone2,
+						machineClassPool3Zone1,
+						machineClassPool3Zone2,
+					}}
+
+					DeferCleanup(testutils.WithFeatureGate(feature.MutableGate, feature.UseSTACKITMachineControllerManager, useStackitMCM))
+
+					mockStackitClient = mockstackitclient.NewMockFactory(ctrl)
+					if cluster.Shoot.Annotations == nil {
+						cluster.Shoot.Annotations = map[string]string{}
+					}
+
+					cluster.Shoot.Annotations[feature.ShootMigrateSTACKITMachineControllerManager] = "true"
+					workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain, mockStackitClient)
+				})
+
+				It("should migrate the machine controller manager", func() {
+					By("creating a machine")
+					machine := &machinev1alpha1.Machine{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "machine-1",
+							Namespace: w.Namespace,
+						},
+						Spec: machinev1alpha1.MachineSpec{
+							Class: machinev1alpha1.ClassSpec{
+								Name: "machineclass",
+							},
+							ProviderID: "openstack:///RegionOne/server-123",
+						},
+					}
+
+					Expect(c.Create(ctx, machine)).To(Succeed())
+
+					By("creating a machine class")
+					machineClassPath := filepath.Join("internal", "machineclass")
+					if useStackitMCM {
+						machineClassPath = filepath.Join("internal", "machineclass-stackit")
+					}
+
+					chartApplier.
+						EXPECT().
+						ApplyFromEmbeddedFS(
+							ctx,
+							charts.InternalChart,
+							machineClassPath,
+							w.Namespace,
+							"machineclass",
+							kubernetes.Values(machineClasses),
+						).
+						Return(nil)
+
+					Expect(workerDelegate.DeployMachineClasses(ctx)).To(Succeed())
+
+					By("enabling the feature gate")
+					DeferCleanup(testutils.WithFeatureGate(feature.MutableGate, feature.UseSTACKITMachineControllerManager, true))
+					DeferCleanup(testutils.WithFeatureGate(feature.MutableGate, feature.MigrateSTACKITMachineControllerManager, true))
+
+					//mockstackitclient.NewMockIaaSClient(ctrl).EXPECT().UpdateServer(ctx, "server-123", iaas2.UpdateServerPayload{
+					//	Labels: map[string]any{
+					//		"mcm.gardener.cloud/machine":      machine.Name,
+					//		"mcm.gardener.cloud/machineclass": machine.Spec.Class.Name,
+					//		"mcm.gardener.cloud/role":         "node",
+					//	},
+					//}).Return(nil, nil)
+
+					mockIaaSClient := mockstackitclient.NewMockIaaSClient(ctrl)
+
+					mockStackitClient.EXPECT().
+						IaaS(ctx, c, w.Spec.SecretRef).
+						Return(mockIaaSClient, nil)
+
+					mockIaaSClient.EXPECT().
+						ProjectID().
+						Return("project-id-123")
+
+					mockIaaSClient.EXPECT().
+						UpdateServer(ctx, "server-123", iaas2.UpdateServerPayload{
+							Labels: map[string]any{
+								"mcm.gardener.cloud/machine":      machine.Name,
+								"mcm.gardener.cloud/machineclass": machine.Spec.Class.Name,
+								"mcm.gardener.cloud/role":         "node",
+							},
+						}).
+						Return(nil, nil)
+
+					By("checking for the migrated machine")
+					migratedMachine := &machinev1alpha1.Machine{}
+
+					Expect(c.Get(ctx, client.ObjectKey{
+						Name:      "machine-1",
+						Namespace: w.Namespace,
+					}, migratedMachine)).To(Succeed())
+
+					Expect(migratedMachine.Spec.ProviderID).
+						To(Equal("stackit://project-id-123/server-123"))
+
+					Expect(migratedMachine.Annotations).
+						To(HaveKeyWithValue("stackit.cloud/migrated-machine", "true"))
+
+					// TODO: how do i check this, as the annotation will get removed soon after the migration
+					//Expect(migratedMachine.Annotations).
+					//	NotTo(HaveKey("stackit.cloud/machine-should-be-migrated"))
+
+					By("checking for the worker")
+					migratedWorker := &extensionsv1alpha1.Worker{}
+
+					Expect(c.Get(ctx, client.ObjectKey{
+						Name:      w.Name,
+						Namespace: w.Namespace,
+					}, migratedWorker)).To(Succeed())
+
+					Expect(migratedWorker.Annotations).
+						To(HaveKeyWithValue(
+							"stackit.cloud/machine-controller-manager-migrated",
+							"true",
+						))
 				})
 			})
 

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -977,68 +977,10 @@ var _ = Describe("Machines", func() {
 			})
 
 			Context("MCM migration", func() {
-				var (
-					defaultMachineClass map[string]any
-					machineClasses      map[string]any
-				)
+				var machine *machinev1alpha1.Machine
 
 				BeforeEach(func() {
-					defaultMachineClass = map[string]any{
-						"region":          region,
-						"keyName":         keyName,
-						"networkID":       networkID,
-						"podNetworkCIDRs": []string{podCIDR},
-						"securityGroups":  []string{securityGroupName},
-						"tags": map[string]string{
-							fmt.Sprintf("kubernetes.io-cluster-%s", technicalID): "1",
-							"kubernetes.io-role-node":                            "1",
-						},
-						"secret": map[string]any{
-							"cloudConfig": string(userData),
-						},
-						"operatingSystem": map[string]any{
-							"operatingSystemName":    machineImageName,
-							"operatingSystemVersion": strings.ReplaceAll(machineImageVersion, "+", "_"),
-						},
-					}
-
-					if useStackitMCM {
-						securityGroupID := "sg-12345"
-						// STACKIT uses security group IDs and simplified tags
-						defaultMachineClass["securityGroups"] = []string{securityGroupID}
-						defaultMachineClass["tags"] = map[string]string{
-							"kubernetes.io/cluster": technicalID,
-						}
-						// Note: subnetID is NOT included for STACKIT
-					} else {
-						// OpenStack uses security group names, full tags, and subnetID
-						defaultMachineClass["securityGroups"] = []string{securityGroupName}
-						defaultMachineClass["tags"] = map[string]string{
-							fmt.Sprintf("kubernetes.io-cluster-%s", technicalID): "1",
-							"kubernetes.io-role-node":                            "1",
-						}
-						defaultMachineClass["subnetID"] = subnetID
-					}
-
-					var (
-						machineClassPool1Zone1 = addKeyValueToMap(defaultMachineClass, "availabilityZone", zone1)
-						machineClassPool1Zone2 = addKeyValueToMap(defaultMachineClass, "availabilityZone", zone2)
-						machineClassPool2Zone1 = addKeyValueToMap(defaultMachineClass, "availabilityZone", zone1)
-						machineClassPool2Zone2 = addKeyValueToMap(defaultMachineClass, "availabilityZone", zone2)
-						machineClassPool3Zone1 = addKeyValueToMap(defaultMachineClass, "availabilityZone", zone1)
-						machineClassPool3Zone2 = addKeyValueToMap(defaultMachineClass, "availabilityZone", zone2)
-					)
-
-					machineClasses = map[string]any{"machineClasses": []map[string]any{
-						machineClassPool1Zone1,
-						machineClassPool1Zone2,
-						machineClassPool2Zone1,
-						machineClassPool2Zone2,
-						machineClassPool3Zone1,
-						machineClassPool3Zone2,
-					}}
-
-					DeferCleanup(testutils.WithFeatureGate(feature.MutableGate, feature.UseSTACKITMachineControllerManager, useStackitMCM))
+					DeferCleanup(testutils.WithFeatureGate(feature.MutableGate, feature.UseSTACKITMachineControllerManager, true))
 
 					mockStackitClient = mockstackitclient.NewMockFactory(ctrl)
 					if cluster.Shoot.Annotations == nil {
@@ -1047,11 +989,8 @@ var _ = Describe("Machines", func() {
 
 					cluster.Shoot.Annotations[feature.ShootMigrateSTACKITMachineControllerManager] = "true"
 					workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customLabelDomain, mockStackitClient)
-				})
 
-				It("should migrate the machine controller manager", func() {
-					By("creating a machine")
-					machine := &machinev1alpha1.Machine{
+					machine = &machinev1alpha1.Machine{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "machine-1",
 							Namespace: w.Namespace,
@@ -1066,38 +1005,20 @@ var _ = Describe("Machines", func() {
 
 					Expect(c.Create(ctx, machine)).To(Succeed())
 
-					By("creating a machine class")
-					machineClassPath := filepath.Join("internal", "machineclass")
-					if useStackitMCM {
-						machineClassPath = filepath.Join("internal", "machineclass-stackit")
-					}
-
 					chartApplier.
 						EXPECT().
 						ApplyFromEmbeddedFS(
 							ctx,
 							charts.InternalChart,
-							machineClassPath,
+							filepath.Join("internal", "machineclass-stackit"),
 							w.Namespace,
 							"machineclass",
-							kubernetes.Values(machineClasses),
+							gomock.Any(),
 						).
 						Return(nil)
+				})
 
-					Expect(workerDelegate.DeployMachineClasses(ctx)).To(Succeed())
-
-					By("enabling the feature gate")
-					DeferCleanup(testutils.WithFeatureGate(feature.MutableGate, feature.UseSTACKITMachineControllerManager, true))
-					DeferCleanup(testutils.WithFeatureGate(feature.MutableGate, feature.MigrateSTACKITMachineControllerManager, true))
-
-					//mockstackitclient.NewMockIaaSClient(ctrl).EXPECT().UpdateServer(ctx, "server-123", iaas2.UpdateServerPayload{
-					//	Labels: map[string]any{
-					//		"mcm.gardener.cloud/machine":      machine.Name,
-					//		"mcm.gardener.cloud/machineclass": machine.Spec.Class.Name,
-					//		"mcm.gardener.cloud/role":         "node",
-					//	},
-					//}).Return(nil, nil)
-
+				It("should migrate the machine controller manager", func() {
 					mockIaaSClient := mockstackitclient.NewMockIaaSClient(ctrl)
 
 					mockStackitClient.EXPECT().
@@ -1118,6 +1039,8 @@ var _ = Describe("Machines", func() {
 						}).
 						Return(nil, nil)
 
+					Expect(workerDelegate.DeployMachineClasses(ctx)).To(Succeed())
+
 					By("checking for the migrated machine")
 					migratedMachine := &machinev1alpha1.Machine{}
 
@@ -1132,9 +1055,8 @@ var _ = Describe("Machines", func() {
 					Expect(migratedMachine.Annotations).
 						To(HaveKeyWithValue("stackit.cloud/migrated-machine", "true"))
 
-					// TODO: how do i check this, as the annotation will get removed soon after the migration
-					//Expect(migratedMachine.Annotations).
-					//	NotTo(HaveKey("stackit.cloud/machine-should-be-migrated"))
+					Expect(migratedMachine.Annotations).
+						NotTo(HaveKey("stackit.cloud/machine-should-be-migrated"))
 
 					By("checking for the worker")
 					migratedWorker := &extensionsv1alpha1.Worker{}

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -1072,6 +1072,83 @@ var _ = Describe("Machines", func() {
 							"true",
 						))
 				})
+
+				It("should retry a machine after an IaaS API failure without touching migrated machines", func() {
+					migratedMachine := &machinev1alpha1.Machine{}
+					Expect(c.Get(ctx, client.ObjectKey{Name: machine.Name, Namespace: machine.Namespace}, migratedMachine)).To(Succeed())
+					migratedMachine.Spec.ProviderID = "stackit://project-id-123/server-123"
+					migratedMachine.Annotations = map[string]string{"stackit.cloud/migrated-machine": "true"}
+					Expect(c.Update(ctx, migratedMachine)).To(Succeed())
+					expectedMigratedMachine := migratedMachine.DeepCopy()
+
+					pendingMachine := &machinev1alpha1.Machine{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "machine-2",
+							Namespace:   w.Namespace,
+							Annotations: map[string]string{"stackit.cloud/machine-should-be-migrated": "true", "stackit.cloud/migrated-machine": "true"},
+						},
+						Spec: machinev1alpha1.MachineSpec{
+							Class:      machinev1alpha1.ClassSpec{Name: "machineclass"},
+							ProviderID: "stackit://project-id-123/server-456",
+						},
+					}
+					Expect(c.Create(ctx, pendingMachine)).To(Succeed())
+
+					failingIaaSClient := mockstackitclient.NewMockIaaSClient(ctrl)
+					mockStackitClient.EXPECT().
+						IaaS(ctx, c, w.Spec.SecretRef).
+						Return(failingIaaSClient, nil)
+					failingIaaSClient.EXPECT().ProjectID().Return("project-id-123")
+					failingIaaSClient.EXPECT().
+						UpdateServer(ctx, "server-456", iaas2.UpdateServerPayload{
+							Labels: map[string]any{
+								"mcm.gardener.cloud/machine":      pendingMachine.Name,
+								"mcm.gardener.cloud/machineclass": pendingMachine.Spec.Class.Name,
+								"mcm.gardener.cloud/role":         "node",
+							},
+						}).
+						Return(nil, fmt.Errorf("temporary IaaS API failure"))
+
+					Expect(workerDelegate.DeployMachineClasses(ctx)).To(MatchError(ContainSubstring("temporary IaaS API failure")))
+
+					failedMachine := &machinev1alpha1.Machine{}
+					Expect(c.Get(ctx, client.ObjectKey{Name: pendingMachine.Name, Namespace: pendingMachine.Namespace}, failedMachine)).To(Succeed())
+					Expect(failedMachine.Annotations).To(HaveKeyWithValue("stackit.cloud/machine-should-be-migrated", "true"))
+
+					unchangedMigratedMachine := &machinev1alpha1.Machine{}
+					Expect(c.Get(ctx, client.ObjectKey{Name: machine.Name, Namespace: machine.Namespace}, unchangedMigratedMachine)).To(Succeed())
+					Expect(unchangedMigratedMachine).To(Equal(expectedMigratedMachine))
+
+					retryIaaSClient := mockstackitclient.NewMockIaaSClient(ctrl)
+					mockStackitClient.EXPECT().
+						IaaS(ctx, c, w.Spec.SecretRef).
+						Return(retryIaaSClient, nil)
+					retryIaaSClient.EXPECT().ProjectID().Return("project-id-123")
+					retryIaaSClient.EXPECT().
+						UpdateServer(ctx, "server-456", iaas2.UpdateServerPayload{
+							Labels: map[string]any{
+								"mcm.gardener.cloud/machine":      pendingMachine.Name,
+								"mcm.gardener.cloud/machineclass": pendingMachine.Spec.Class.Name,
+								"mcm.gardener.cloud/role":         "node",
+							},
+						}).
+						Return(nil, nil)
+					chartApplier.EXPECT().
+						ApplyFromEmbeddedFS(ctx, charts.InternalChart, filepath.Join("internal", "machineclass-stackit"), w.Namespace, "machineclass", gomock.Any()).
+						Return(nil)
+
+					Expect(workerDelegate.DeployMachineClasses(ctx)).To(Succeed())
+
+					retriedMachine := &machinev1alpha1.Machine{}
+					Expect(c.Get(ctx, client.ObjectKey{Name: pendingMachine.Name, Namespace: pendingMachine.Namespace}, retriedMachine)).To(Succeed())
+					Expect(retriedMachine.Annotations).NotTo(HaveKey("stackit.cloud/machine-should-be-migrated"))
+					Expect(c.Get(ctx, client.ObjectKey{Name: machine.Name, Namespace: machine.Namespace}, unchangedMigratedMachine)).To(Succeed())
+					Expect(unchangedMigratedMachine).To(Equal(expectedMigratedMachine))
+
+					migratedWorker := &extensionsv1alpha1.Worker{}
+					Expect(c.Get(ctx, client.ObjectKey{Name: w.Name, Namespace: w.Namespace}, migratedWorker)).To(Succeed())
+					Expect(migratedWorker.Annotations).To(HaveKeyWithValue("stackit.cloud/machine-controller-manager-migrated", "true"))
+				})
 			})
 
 			It("should fail because the infrastructure status cannot be decoded", func() {

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -22,8 +22,12 @@ const (
 	UseSTACKITAPIInfrastructureController featuregate.Feature = "UseSTACKITAPIInfrastructureController"
 	// UseSTACKITMachineControllerManager Uses the STACKIT machine controller Manager to manage nodes.
 	UseSTACKITMachineControllerManager featuregate.Feature = "UseSTACKITMachineControllerManager"
+	// MigrateSTACKITMachineControllerManager Migrates the existing openstack machines to stackit. Only works if feature gate UseSTACKITMachineControllerManager is enabled.
+	MigrateSTACKITMachineControllerManager featuregate.Feature = "MigrateSTACKITMachineControllerManager"
 	// ShootUseSTACKITMachineControllerManager Uses the STACKIT machine controller Manager to manage nodes for a specific Shoot.
 	ShootUseSTACKITMachineControllerManager = "shoot.gardener.cloud/use-stackit-machine-controller-manager"
+	// ShootMigrateSTACKITMachineControllerManager Migrates the existing openstack machines to stackit. Only works if feature gate UseSTACKITMachineControllerManager is enabled.
+	ShootMigrateSTACKITMachineControllerManager = "shoot.gardener.cloud/migrate-stackit-machine-controller-manager"
 	// ShootUseSTACKITAPIInfrastructureController Uses the STACKIT API to create the shoot resources instead of OpenStack for a specific Shoot.
 	ShootUseSTACKITAPIInfrastructureController = "shoot.gardener.cloud/use-stackit-api-infrastructure-controller"
 	// EnableSTACKITWorkloadIdentity activates the deployment of the stackit-pod-identity-webhook to enable workload identity injection into pods.
@@ -44,11 +48,12 @@ var (
 	Gate featuregate.FeatureGate = MutableGate
 
 	allGates = map[featuregate.Feature]featuregate.FeatureSpec{
-		EnsureSTACKITLBDeletion:               {Default: true, PreRelease: featuregate.Alpha},
-		EnsureSTACKITALBDeletion:              {Default: false, PreRelease: featuregate.Alpha},
-		UseSTACKITAPIInfrastructureController: {Default: true, PreRelease: featuregate.Alpha},
-		UseSTACKITMachineControllerManager:    {Default: true, PreRelease: featuregate.Alpha},
-		EnableSTACKITWorkloadIdentity:         {Default: false, PreRelease: featuregate.Alpha},
+		EnsureSTACKITLBDeletion:                {Default: true, PreRelease: featuregate.Alpha},
+		EnsureSTACKITALBDeletion:               {Default: false, PreRelease: featuregate.Alpha},
+		UseSTACKITAPIInfrastructureController:  {Default: true, PreRelease: featuregate.Alpha},
+		UseSTACKITMachineControllerManager:     {Default: true, PreRelease: featuregate.Alpha},
+		EnableSTACKITWorkloadIdentity:          {Default: false, PreRelease: featuregate.Alpha},
+		MigrateSTACKITMachineControllerManager: {Default: false, PreRelease: featuregate.Alpha},
 	}
 )
 
@@ -80,4 +85,21 @@ func UseStackitAPIInfrastructureController(cluster *extensionscontroller.Cluster
 		}
 	}
 	return Gate.Enabled(UseSTACKITAPIInfrastructureController)
+}
+
+func MigrateStackitMachineControllerManager(cluster *extensionscontroller.Cluster) bool {
+	if !UseStackitMachineControllerManager(cluster) {
+		return false
+	}
+
+	if cluster != nil && cluster.Shoot != nil {
+		annotation, ok := cluster.Shoot.Annotations[ShootMigrateSTACKITMachineControllerManager]
+		if ok {
+			enabledByAnnotation, err := strconv.ParseBool(annotation)
+			if err == nil {
+				return enabledByAnnotation
+			}
+		}
+	}
+	return Gate.Enabled(MigrateSTACKITMachineControllerManager)
 }

--- a/pkg/stackit/client/iaas.go
+++ b/pkg/stackit/client/iaas.go
@@ -36,6 +36,7 @@ type IaaSClient interface {
 
 	CreateServer(ctx context.Context, payload iaas.CreateServerPayload) (*iaas.Server, error)
 	DeleteServer(ctx context.Context, serverId string) error
+	UpdateServer(ctx context.Context, serverId string, payload iaas.UpdateServerPayload) (*iaas.Server, error)
 	GetServerByName(ctx context.Context, name string) ([]iaas.Server, error)
 
 	CreatePublicIp(ctx context.Context, payload iaas.CreatePublicIPPayload) (*iaas.PublicIp, error)
@@ -286,6 +287,10 @@ func (c iaasClient) CreateServer(ctx context.Context, payload iaas.CreateServerP
 
 func (c iaasClient) DeleteServer(ctx context.Context, serverId string) error {
 	return c.Client.DeleteServer(ctx, c.projectID, c.region, serverId).Execute()
+}
+
+func (c iaasClient) UpdateServer(ctx context.Context, serverId string, payload iaas.UpdateServerPayload) (*iaas.Server, error) {
+	return c.Client.UpdateServer(ctx, c.projectID, c.region, serverId).UpdateServerPayload(payload).Execute()
 }
 
 // GetServerByName finds the first server with the given name.

--- a/pkg/stackit/client/mock/iaas_mock.go
+++ b/pkg/stackit/client/mock/iaas_mock.go
@@ -379,3 +379,18 @@ func (mr *MockIaaSClientMockRecorder) UpdateSecurityGroupRules(ctx, group, desir
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRules", reflect.TypeOf((*MockIaaSClient)(nil).UpdateSecurityGroupRules), ctx, group, desiredRules, allowDelete)
 }
+
+// UpdateServer mocks base method.
+func (m *MockIaaSClient) UpdateServer(ctx context.Context, serverId string, payload v2api.UpdateServerPayload) (*v2api.Server, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateServer", ctx, serverId, payload)
+	ret0, _ := ret[0].(*v2api.Server)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateServer indicates an expected call of UpdateServer.
+func (mr *MockIaaSClientMockRecorder) UpdateServer(ctx, serverId, payload any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateServer", reflect.TypeOf((*MockIaaSClient)(nil).UpdateServer), ctx, serverId, payload)
+}


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:

This PR replaces mcm provider from openstack to stackit. Replaces openstack provider ID with stackit provider ID and add `stackit.cloud/migrated-machine: true` annotation to machines and puts annotation `stackit.cloud/machine-controller-manager-migrated: true` to workers once the migration is done.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
