### PR TITLE
Make floatingPoolName optional

### DIFF
--- a/pkg/apis/stackit/validation/infrastructure.go
+++ b/pkg/apis/stackit/validation/infrastructure.go
@@ -5,8 +5,6 @@
 package validation
 
 import (
-	"slices"
-
 	cidrvalidation "github.com/gardener/gardener/pkg/utils/validation/cidr"
 	"github.com/google/uuid"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
@@ -18,10 +16,6 @@ import (
 // ValidateInfrastructureConfig validates a InfrastructureConfig object.
 func ValidateInfrastructureConfig(infra *stackitv1alpha1.InfrastructureConfig, nodesCIDR *string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-
-	if len(infra.FloatingPoolName) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("floatingPoolName"), "must provide the name of a floating pool"))
-	}
 
 	networksPath := fldPath.Child("networks")
 
@@ -104,24 +98,8 @@ func ValidateInfrastructureConfigUpdate(oldConfig, newConfig *stackitv1alpha1.In
 }
 
 // ValidateInfrastructureConfigAgainstCloudProfile validates the given InfrastructureConfig against constraints in the given CloudProfile.
-func ValidateInfrastructureConfigAgainstCloudProfile(oldInfra, infra *stackitv1alpha1.InfrastructureConfig, cloudProfileConfig *stackitv1alpha1.CloudProfileConfig, fldPath *field.Path) field.ErrorList {
+func ValidateInfrastructureConfigAgainstCloudProfile(_, _ *stackitv1alpha1.InfrastructureConfig, _ *stackitv1alpha1.CloudProfileConfig, _ *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if oldInfra == nil || oldInfra.FloatingPoolName != infra.FloatingPoolName {
-		//nolint:staticcheck // SA1019: needed for migration purposes
-		allErrs = append(allErrs, validateFloatingPoolNameConstraints(cloudProfileConfig.Constraints.FloatingPools, infra.FloatingPoolName, fldPath.Child("floatingPoolName")))
-	}
-
 	return allErrs
-}
-
-func validateFloatingPoolNameConstraints(fps []stackitv1alpha1.FloatingPool, name string, fldPath *field.Path) *field.Error {
-	availablePoolNames := make([]string, 0, len(fps))
-	for _, fp := range fps {
-		availablePoolNames = append(availablePoolNames, fp.Name)
-	}
-	if !slices.Contains(availablePoolNames, name) {
-		return field.NotSupported(fldPath, name, availablePoolNames)
-	}
-	return nil
 }

--- a/pkg/apis/stackit/validation/infrastructure_test.go
+++ b/pkg/apis/stackit/validation/infrastructure_test.go
@@ -38,15 +38,12 @@ var _ = Describe("InfrastructureConfig validation", func() {
 	})
 
 	Describe("#ValidateInfrastructureConfig", func() {
-		It("should forbid invalid floating pool name configuration", func() {
+		It("should allow empty floating pool name configuration", func() {
 			infrastructureConfig.FloatingPoolName = ""
 
 			errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, nilPath)
 
-			Expect(errorList).To(ConsistOfFields(Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("floatingPoolName"),
-			}))
+			Expect(errorList).To(BeEmpty())
 		})
 
 		It("should forbid invalid router id configuration", func() {
@@ -239,42 +236,5 @@ var _ = Describe("InfrastructureConfig validation", func() {
 				"Field": Equal("floatingPoolSubnetName"),
 			}))))
 		})
-	})
-
-	Describe("#ValidateInfrastructureConfigAgainstCloudProfile", func() {
-		var cloudProfileConfig *stackitv1alpha1.CloudProfileConfig
-
-		BeforeEach(func() {
-			cloudProfileConfig = &stackitv1alpha1.CloudProfileConfig{
-				Constraints: stackitv1alpha1.Constraints{
-					FloatingPools: []stackitv1alpha1.FloatingPool{
-						{
-							Name: floatingPoolName1,
-						},
-					},
-				},
-			}
-		})
-
-		It("should validate that the floating pool name exists in the cloud profile", func() {
-			oldInfrastructureConfig := infrastructureConfig.DeepCopy()
-			infrastructureConfig.FloatingPoolName = "does-for-sure-not-exist-in-cloudprofile"
-
-			errorList := ValidateInfrastructureConfigAgainstCloudProfile(oldInfrastructureConfig, infrastructureConfig, cloudProfileConfig, nilPath)
-			Expect(errorList).To(ConsistOfFields(Fields{
-				"Type":     Equal(field.ErrorTypeNotSupported),
-				"Field":    Equal("floatingPoolName"),
-				"BadValue": Equal("does-for-sure-not-exist-in-cloudprofile"),
-			}))
-		})
-
-		It("should not validate anything if the floating pool name was not changed", func() {
-			infrastructureConfig.FloatingPoolName = "does-for-sure-not-exist-in-cloudprofile"
-			oldInfrastructureConfig := infrastructureConfig.DeepCopy()
-
-			errorList := ValidateInfrastructureConfigAgainstCloudProfile(oldInfrastructureConfig, infrastructureConfig, cloudProfileConfig, nilPath)
-			Expect(errorList).To(BeEmpty())
-		})
-
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement
/cc @stackitcloud/ske-infrastructure 

**What this PR does / why we need it**:
The `floatingPoolName` was required but never used in a STACKIT only Cluster (since the validation is in place #212). It is only used in the STACKIT Infra-Controller in case there are OpenStack Credentials to pull the IDs of it in the Status.

This PR removes the validation (we know we need it for clusters with OpenStack). To not make the unrelevant field for STACKIT Only clusters required. 


There will be a followup PR (#281) which also further cleans up the `floatingPoolName` and other fields in the  `InfrastructureConfig`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
