### PR TITLE
Deprecate OpenStack only fields in InfrastructureConfig

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -94,6 +94,9 @@ linters:
       - linters:
           - nolintlint
         text: "should be written without leading space as `//nolint" # don't require machine-readable nolint directives (i.e. with no leading space)
+      - linters:
+          - staticcheck
+        text: "SA1019:.*OpenStack-only; not used for STACKIT."
     paths:
       - zz_generated\..*\.go$
 

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -889,6 +889,8 @@ boolean
 
 <p>
 FloatingPoolStatus contains information about the floating pool.
+
+Deprecated: OpenStack-only; not used for STACKIT.
 </p>
 
 <table>
@@ -908,7 +910,7 @@ string
 </em>
 </td>
 <td>
-<p>ID is the floating pool id.</p>
+<p>ID is the floating pool id.<br />Deprecated: OpenStack-only; not used for STACKIT.</p>
 </td>
 </tr>
 <tr>
@@ -919,7 +921,7 @@ string
 </em>
 </td>
 <td>
-<p>Name is the floating pool name.</p>
+<p>Name is the floating pool name.<br />Deprecated: OpenStack-only; not used for STACKIT.</p>
 </td>
 </tr>
 
@@ -952,7 +954,8 @@ string
 </em>
 </td>
 <td>
-<p>FloatingPoolName contains the FloatingPoolName name in which LoadBalancer FIPs should be created.</p>
+<em>(Optional)</em>
+<p>FloatingPoolName contains the FloatingPoolName name in which LoadBalancer FIPs should be created.<br />Deprecated: OpenStack-only; not used for STACKIT.</p>
 </td>
 </tr>
 <tr>
@@ -964,7 +967,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>FloatingPoolSubnetName contains the fixed name of subnet or matching name pattern for subnet<br />in the Floating IP Pool where the router should be attached to.</p>
+<p>FloatingPoolSubnetName contains the fixed name of subnet or matching name pattern for subnet<br />in the Floating IP Pool where the router should be attached to.<br />Deprecated: OpenStack-only; not used for STACKIT.</p>
 </td>
 </tr>
 <tr>
@@ -1562,7 +1565,7 @@ string
 </em>
 </td>
 <td>
-<p>FloatingPool contains information about the floating pool.</p>
+<p>FloatingPool contains information about the floating pool.<br />Deprecated: OpenStack-only; not used for STACKIT.</p>
 </td>
 </tr>
 <tr>
@@ -1573,7 +1576,7 @@ string
 </em>
 </td>
 <td>
-<p>Router contains information about the Router and related resources.</p>
+<p>Router contains information about the Router and related resources.<br />Deprecated: OpenStack-only; not used for STACKIT.</p>
 </td>
 </tr>
 <tr>
@@ -1646,7 +1649,7 @@ Networks holds information about the Kubernetes and infrastructure networks.
 </td>
 <td>
 <em>(Optional)</em>
-<p>Router indicates whether to use an existing router or create a new one.</p>
+<p>Router indicates whether to use an existing router or create a new one.<br />Deprecated: OpenStack-only; not used for STACKIT.</p>
 </td>
 </tr>
 <tr>
@@ -1692,7 +1695,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>SubnetID is the ID of an existing subnet.</p>
+<p>SubnetID is the ID of an existing subnet.<br />Deprecated: OpenStack-only; not used for STACKIT.</p>
 </td>
 </tr>
 <tr>
@@ -1882,6 +1885,8 @@ string
 
 <p>
 RouterStatus contains information about a generated Router or resources attached to an existing Router.
+
+Deprecated: OpenStack-only; not used for STACKIT.
 </p>
 
 <table>
@@ -1901,7 +1906,7 @@ string
 </em>
 </td>
 <td>
-<p>ID is the Router id.</p>
+<p>ID is the Router id.<br />Deprecated: OpenStack-only; not used for STACKIT.</p>
 </td>
 </tr>
 <tr>
@@ -1912,7 +1917,7 @@ string
 </em>
 </td>
 <td>
-<p>IP is the router ip.<br />Deprecated: use ExternalFixedIPs instead.</p>
+<p>IP is the router ip.<br />Deprecated: use ExternalFixedIPs instead. OpenStack-only; not used for STACKIT.</p>
 </td>
 </tr>
 <tr>
@@ -1923,7 +1928,7 @@ string array
 </em>
 </td>
 <td>
-<p>ExternalFixedIPs is the list of the router's assigned external fixed IPs.</p>
+<p>ExternalFixedIPs is the list of the router's assigned external fixed IPs.<br />Deprecated: OpenStack-only; not used for STACKIT.</p>
 </td>
 </tr>
 
@@ -2132,6 +2137,8 @@ boolean
 
 <p>
 ShareNetworkStatus contains information about a generated ShareNetwork
+
+Deprecated: OpenStack-only; not used for STACKIT.
 </p>
 
 <table>
@@ -2151,7 +2158,7 @@ string
 </em>
 </td>
 <td>
-<p>ID is the Network id.</p>
+<p>ID is the Network id.<br />Deprecated: OpenStack-only; not used for STACKIT.</p>
 </td>
 </tr>
 <tr>
@@ -2162,7 +2169,7 @@ string
 </em>
 </td>
 <td>
-<p>Name is the Network name.</p>
+<p>Name is the Network name.<br />Deprecated: OpenStack-only; not used for STACKIT.</p>
 </td>
 </tr>
 
@@ -2351,6 +2358,8 @@ string
 
 <p>
 Subnet is an OpenStack subnet related to a Network.
+
+Deprecated: OpenStack-only; not used for STACKIT.
 </p>
 
 <table>
@@ -2370,7 +2379,7 @@ Subnet is an OpenStack subnet related to a Network.
 </em>
 </td>
 <td>
-<p>Purpose is a logical description of the subnet.</p>
+<p>Purpose is a logical description of the subnet.<br />Deprecated: OpenStack-only; not used for STACKIT.</p>
 </td>
 </tr>
 <tr>
@@ -2381,7 +2390,7 @@ string
 </em>
 </td>
 <td>
-<p>ID is the subnet id.</p>
+<p>ID is the subnet id.<br />Deprecated: OpenStack-only; not used for STACKIT.</p>
 </td>
 </tr>
 <tr>
@@ -2393,7 +2402,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>DNSNameservers specifies the DNS nameservers for the subnet.<br />Nil if DNSNameservers could not be queried.</p>
+<p>DNSNameservers specifies the DNS nameservers for the subnet.<br />Nil if DNSNameservers could not be queried.<br />Deprecated: OpenStack-only; not used for STACKIT.</p>
 </td>
 </tr>
 

--- a/pkg/apis/stackit/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/stackit/v1alpha1/types_infrastructure.go
@@ -15,9 +15,14 @@ import (
 type InfrastructureConfig struct {
 	metav1.TypeMeta `json:",inline"`
 	// FloatingPoolName contains the FloatingPoolName name in which LoadBalancer FIPs should be created.
+	//
+	// Deprecated: OpenStack-only; not used for STACKIT.
+	// +optional
 	FloatingPoolName string `json:"floatingPoolName"`
 	// FloatingPoolSubnetName contains the fixed name of subnet or matching name pattern for subnet
 	// in the Floating IP Pool where the router should be attached to.
+	//
+	// Deprecated: OpenStack-only; not used for STACKIT.
 	// +optional
 	FloatingPoolSubnetName *string `json:"floatingPoolSubnetName,omitempty"`
 	// Networks is the OpenStack specific network configuration
@@ -27,6 +32,8 @@ type InfrastructureConfig struct {
 // Networks holds information about the Kubernetes and infrastructure networks.
 type Networks struct {
 	// Router indicates whether to use an existing router or create a new one.
+	//
+	// Deprecated: OpenStack-only; not used for STACKIT.
 	// +optional
 	Router *Router `json:"router,omitempty"`
 	// Worker is a CIDRs of a worker subnet (private) to create (used for the VMs).
@@ -39,6 +46,8 @@ type Networks struct {
 	// +optional
 	ID *string `json:"id,omitempty"`
 	// SubnetID is the ID of an existing subnet.
+	//
+	// Deprecated: OpenStack-only; not used for STACKIT.
 	// +optional
 	SubnetID *string `json:"subnetId,omitempty"`
 	// ShareNetwork holds information about the share network (used for shared file systems like NFS)
@@ -91,8 +100,12 @@ type NetworkStatus struct {
 	// Name is the Network name.
 	Name string `json:"name"`
 	// FloatingPool contains information about the floating pool.
+	//
+	// Deprecated: OpenStack-only; not used for STACKIT.
 	FloatingPool FloatingPoolStatus `json:"floatingPool"`
 	// Router contains information about the Router and related resources.
+	//
+	// Deprecated: OpenStack-only; not used for STACKIT.
 	Router RouterStatus `json:"router"`
 	// DNSServer contains the networks configured dnsServers
 	// +optional
@@ -109,30 +122,48 @@ type NetworkStatus struct {
 }
 
 // RouterStatus contains information about a generated Router or resources attached to an existing Router.
+//
+// Deprecated: OpenStack-only; not used for STACKIT.
 type RouterStatus struct {
 	// ID is the Router id.
+	//
+	// Deprecated: OpenStack-only; not used for STACKIT.
 	ID string `json:"id"`
 	// IP is the router ip.
 	//
-	// Deprecated: use ExternalFixedIPs instead.
+	// Deprecated: use ExternalFixedIPs instead. OpenStack-only; not used for STACKIT.
 	IP string `json:"ip"`
 	// ExternalFixedIPs is the list of the router's assigned external fixed IPs.
+	//
+	// Deprecated: OpenStack-only; not used for STACKIT.
 	ExternalFixedIPs []string `json:"externalFixedIP"`
 }
 
 // FloatingPoolStatus contains information about the floating pool.
+//
+// Deprecated: OpenStack-only; not used for STACKIT.
 type FloatingPoolStatus struct {
 	// ID is the floating pool id.
+	//
+	// Deprecated: OpenStack-only; not used for STACKIT.
 	ID string `json:"id"`
 	// Name is the floating pool name.
+	//
+	// Deprecated: OpenStack-only; not used for STACKIT.
 	Name string `json:"name"`
 }
 
 // ShareNetworkStatus contains information about a generated ShareNetwork
+//
+// Deprecated: OpenStack-only; not used for STACKIT.
 type ShareNetworkStatus struct {
 	// ID is the Network id.
+	//
+	// Deprecated: OpenStack-only; not used for STACKIT.
 	ID string `json:"id"`
 	// Name is the Network name.
+	//
+	// Deprecated: OpenStack-only; not used for STACKIT.
 	Name string `json:"name"`
 }
 
@@ -145,13 +176,21 @@ const (
 )
 
 // Subnet is an OpenStack subnet related to a Network.
+//
+// Deprecated: OpenStack-only; not used for STACKIT.
 type Subnet struct {
 	// Purpose is a logical description of the subnet.
+	//
+	// Deprecated: OpenStack-only; not used for STACKIT.
 	Purpose Purpose `json:"purpose"`
 	// ID is the subnet id.
+	//
+	// Deprecated: OpenStack-only; not used for STACKIT.
 	ID string `json:"id"`
 	// DNSNameservers specifies the DNS nameservers for the subnet.
 	// Nil if DNSNameservers could not be queried.
+	//
+	// Deprecated: OpenStack-only; not used for STACKIT.
 	// +optional
 	DNSNameservers *[]string `json:"dnsNameservers,omitempty"`
 }

--- a/pkg/apis/stackit/validation/cloudprofile.go
+++ b/pkg/apis/stackit/validation/cloudprofile.go
@@ -30,7 +30,6 @@ func ValidateCloudProfileConfig(cloudProfile *stackitv1alpha1.CloudProfileConfig
 
 	floatingPoolPath := fldPath.Child("constraints", "floatingPools")
 	combinationFound := sets.NewString()
-	//nolint:staticcheck // SA1019: needed for migration purposes
 	for i, pool := range cloudProfile.Constraints.FloatingPools {
 		idxPath := floatingPoolPath.Index(i)
 		if len(pool.Name) == 0 {
@@ -71,7 +70,6 @@ func ValidateCloudProfileConfig(cloudProfile *stackitv1alpha1.CloudProfileConfig
 	}
 	allErrs = append(allErrs, validateMachineImageMapping(machineImages, cloudProfile, capabilityDefinitions, field.NewPath("spec").Child("machineImages"))...)
 
-	//nolint:staticcheck // SA1019: needed for migration purposes
 	if ca := cloudProfile.KeyStoneCACert; ca != nil && len(*ca) > 0 {
 		_, err := utils.DecodeCertificate([]byte(*ca))
 		if err != nil {
@@ -80,7 +78,6 @@ func ValidateCloudProfileConfig(cloudProfile *stackitv1alpha1.CloudProfileConfig
 	}
 
 	regionsFound := sets.NewString()
-	//nolint:staticcheck // SA1019: needed for migration purposes
 	for i, val := range cloudProfile.KeyStoneURLs {
 		idxPath := fldPath.Child("keyStoneURLs").Index(i)
 
@@ -111,13 +108,11 @@ func ValidateCloudProfileConfig(cloudProfile *stackitv1alpha1.CloudProfileConfig
 		}
 	}
 
-	//nolint:staticcheck // SA1019: needed for migration purposes
 	if cloudProfile.DHCPDomain != nil && len(*cloudProfile.DHCPDomain) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("dhcpDomain"), "must provide a dhcp domain when the key is specified"))
 	}
 
 	serverGroupPath := fldPath.Child("serverGroupPolicies")
-	//nolint:staticcheck // SA1019: needed for migration purposes
 	for i, policy := range cloudProfile.ServerGroupPolicies {
 		idxPath := serverGroupPath.Index(i)
 

--- a/pkg/apis/stackit/validation/cloudprofile_test.go
+++ b/pkg/apis/stackit/validation/cloudprofile_test.go
@@ -93,7 +93,6 @@ var _ = Describe("CloudProfileConfig validation", func() {
 
 		Context("floating pools constraints", func() {
 			It("should forbid unsupported pools", func() {
-				//nolint:staticcheck // SA1019: needed for migration purposes
 				cloudProfileConfig.Constraints.FloatingPools = []stackitv1alpha1.FloatingPool{
 					{
 						Name:   "",
@@ -117,7 +116,6 @@ var _ = Describe("CloudProfileConfig validation", func() {
 			})
 
 			It("should forbid duplicates regions and domains in pools", func() {
-				//nolint:staticcheck // SA1019: needed for migration purposes
 				cloudProfileConfig.Constraints.FloatingPools = []stackitv1alpha1.FloatingPool{
 					{
 						Name:   "foo",
@@ -170,9 +168,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 
 		Context("keystone url validation", func() {
 			It("should forbid keystone urls with missing keys", func() {
-				//nolint:staticcheck // SA1019: needed for migration purposes
 				cloudProfileConfig.KeyStoneURL = ""
-				//nolint:staticcheck // SA1019: needed for migration purposes
 				cloudProfileConfig.KeyStoneURLs = []stackitv1alpha1.KeyStoneURL{{}}
 
 				errorList := ValidateCloudProfileConfig(cloudProfileConfig, machineImages, capabilityDefinitions, fldPath)
@@ -187,9 +183,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 			})
 
 			It("should forbid duplicate regions for keystone urls", func() {
-				//nolint:staticcheck // SA1019: needed for migration purposes
 				cloudProfileConfig.KeyStoneURL = ""
-				//nolint:staticcheck // SA1019: needed for migration purposes
 				cloudProfileConfig.KeyStoneURLs = []stackitv1alpha1.KeyStoneURL{
 					{
 						Region: "foo",
@@ -211,7 +205,6 @@ var _ = Describe("CloudProfileConfig validation", func() {
 		})
 
 		It("should forbid invalid keystone CA Certs", func() {
-			//nolint:staticcheck // SA1019: needed for migration purposes
 			cloudProfileConfig.KeyStoneCACert = new("foo")
 
 			errorList := ValidateCloudProfileConfig(cloudProfileConfig, machineImages, capabilityDefinitions, fldPath)
@@ -237,7 +230,6 @@ var _ = Describe("CloudProfileConfig validation", func() {
 
 		Context("dhcp domain validation", func() {
 			It("should forbid not specifying a value when the key is present", func() {
-				//nolint:staticcheck // SA1019: needed for migration purposes
 				cloudProfileConfig.DHCPDomain = new("")
 
 				errorList := ValidateCloudProfileConfig(cloudProfileConfig, machineImages, capabilityDefinitions, fldPath)
@@ -552,7 +544,6 @@ var _ = Describe("CloudProfileConfig validation", func() {
 
 		Context("server group policy validation", func() {
 			It("should forbid empty server group policy", func() {
-				//nolint:staticcheck // SA1019: needed for migration purposes
 				cloudProfileConfig.ServerGroupPolicies = []string{
 					"affinity",
 					"",

--- a/pkg/apis/stackit/validation/infrastructure.go
+++ b/pkg/apis/stackit/validation/infrastructure.go
@@ -21,12 +21,12 @@ func ValidateInfrastructureConfig(infra *stackitv1alpha1.InfrastructureConfig, n
 
 	// check InfrastructureConfig.networks.worker(s) is a valid cidr and not be set if a network id is provided.
 	var workerCIDR cidrvalidation.CIDR
-	//nolint:staticcheck // SA1019: needed for migration purposes
+	//nolint:staticcheck // SA1019: deprecated will be removed later
 	if infra.Networks.Worker != "" {
-		//nolint:staticcheck // SA1019: needed for migration purposes
+		//nolint:staticcheck // SA1019: deprecated will be removed later
 		workerCIDR = cidrvalidation.NewCIDR(infra.Networks.Worker, networksPath.Child("worker"))
 		allErrs = append(allErrs, cidrvalidation.ValidateCIDRParse(workerCIDR)...)
-		//nolint:staticcheck // SA1019: needed for migration purposes
+		//nolint:staticcheck // SA1019: deprecated will be removed later
 		allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(networksPath.Child("worker"), infra.Networks.Worker)...)
 		if infra.Networks.ID != nil {
 			allErrs = append(allErrs, field.Forbidden(networksPath.Child("worker"), "cant be set if a network id is provided"))

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -69,11 +69,11 @@ func (c *Config) ApplyETCDStorage(etcdStorage *config.ETCDStorage) {
 
 // ApplyRegistryCaches sets the given Registry Cache configurations.
 func (c *Config) ApplyRegistryCaches(regCaches *[]config.RegistryCacheConfiguration) {
-	//nolint:staticcheck // SA1019: needed for migration purposes
+	//nolint:staticcheck // SA1019: deprecated will be removed later
 	if len(c.Config.RegistryCaches) == 0 {
 		return
 	}
-	//nolint:staticcheck // SA1019: needed for migration purposes
+	//nolint:staticcheck // SA1019: deprecated will be removed later
 	*regCaches = c.Config.RegistryCaches
 }
 

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -660,9 +660,7 @@ func getConfigChartValues(
 		values["applicationCredentialName"] = osCredentials.ApplicationCredentialName
 		values["applicationCredentialSecret"] = osCredentials.ApplicationCredentialSecret
 		values["region"] = cp.Spec.Region
-		//nolint:staticcheck // SA1019: needed for migration purposes
 		values["requestTimeout"] = cloudProfileConfig.RequestTimeout
-		//nolint:staticcheck // SA1019: needed for migration purposes
 		values["ignoreVolumeAZ"] = cloudProfileConfig.IgnoreVolumeAZ != nil && *cloudProfileConfig.IgnoreVolumeAZ
 		// detect internal network.
 		// See https://github.com/kubernetes/cloud-provider-openstack/blob/v1.22.1/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#networking
@@ -1285,8 +1283,7 @@ func (vp *valuesProvider) getControlPlaneShootChartCSIValues(ctx context.Context
 	values := map[string]any{
 		"enabled":                    getCSIDriver(cpConfig) == stackitv1alpha1.OPENSTACK,
 		"rescanBlockStorageOnResize": cloudProfileConfig.RescanBlockStorageOnResize != nil && *cloudProfileConfig.RescanBlockStorageOnResize,
-		//nolint:staticcheck // SA1019: needed for migration purposes
-		"nodeVolumeAttachLimit": cloudProfileConfig.NodeVolumeAttachLimit,
+		"nodeVolumeAttachLimit":      cloudProfileConfig.NodeVolumeAttachLimit,
 	}
 
 	if userAgentHeader != nil {

--- a/pkg/controller/infrastructure/openstack/infraflow/context.go
+++ b/pkg/controller/infrastructure/openstack/infraflow/context.go
@@ -192,9 +192,7 @@ func (fctx *FlowContext) computeInfrastructureStatus() *stackitv1alpha1.Infrastr
 
 	status.Networks.Router.ID = ptr.Deref(fctx.state.Get(IdentifierRouter), "")
 	status.Networks.Router.ExternalFixedIPs = fctx.state.GetObject(IdentifierEgressCIDRs).([]string)
-	// backwards compatibility change for the deprecated field
 	if len(status.Networks.Router.ExternalFixedIPs) > 0 {
-		//nolint:staticcheck // SA1019: needed for migration purposes
 		status.Networks.Router.IP = status.Networks.Router.ExternalFixedIPs[0]
 	}
 
@@ -205,7 +203,6 @@ func (fctx *FlowContext) computeInfrastructureStatus() *stackitv1alpha1.Infrastr
 	}
 
 	if v := fctx.state.Get(IdentifierSubnet); v != nil {
-		//nolint:staticcheck // SA1019: Keep support for OpenStack mcm until we completely drop it
 		status.Networks.Subnets = []stackitv1alpha1.Subnet{
 			{
 				Purpose:        stackitv1alpha1.PurposeNodes,

--- a/pkg/controller/infrastructure/openstack/infraflow/context.go
+++ b/pkg/controller/infrastructure/openstack/infraflow/context.go
@@ -163,8 +163,8 @@ func NewFlowContext(ctx context.Context, opts Opts) (*FlowContext, error) {
 }
 
 func (fctx *FlowContext) persistState(ctx context.Context) error {
-	// status is nil such that there's no need to pass the nodesCIDR
-	return infrainternal.PatchProviderStatusAndState(ctx, fctx.client, fctx.infra, nil, nil, fctx.computeInfrastructureState())
+	// status is nil such that there's no need to pass the nodesCIDR and egressCIDRs
+	return infrainternal.PatchProviderStatusAndState(ctx, fctx.client, fctx.infra, nil, nil, nil, fctx.computeInfrastructureState())
 }
 
 func (fctx *FlowContext) computeInfrastructureState() *runtime.RawExtension {

--- a/pkg/controller/infrastructure/openstack/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/openstack/infraflow/reconcile.go
@@ -24,6 +24,7 @@ import (
 	infrainternal "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/internal/infrastructure"
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/openstack/client"
 	stackitclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit/client"
+	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/utils"
 )
 
 const (
@@ -43,7 +44,12 @@ func (fctx *FlowContext) Reconcile(ctx context.Context) error {
 
 	state := fctx.computeInfrastructureState()
 	status := fctx.computeInfrastructureStatus()
-	return infrainternal.PatchProviderStatusAndState(ctx, fctx.client, fctx.infra, status, fctx.nodesCIDR, state)
+	var egressCIDRs []string
+	if status != nil {
+		egressCIDRs = utils.ComputeEgressCIDRs(status.Networks.Router.ExternalFixedIPs)
+	}
+
+	return infrainternal.PatchProviderStatusAndState(ctx, fctx.client, fctx.infra, status, fctx.nodesCIDR, egressCIDRs, state)
 }
 
 func (fctx *FlowContext) buildReconcileGraph() *flow.Graph {
@@ -162,8 +168,7 @@ func (fctx *FlowContext) ensureNewRouter(ctx context.Context, externalNetworkID 
 	desired := &access.Router{
 		Name:              fctx.defaultRouterName(),
 		ExternalNetworkID: externalNetworkID,
-		//nolint:staticcheck // SA1019: needed for migration purposes
-		EnableSNAT: fctx.cloudProfileConfig.UseSNAT,
+		EnableSNAT:        fctx.cloudProfileConfig.UseSNAT,
 	}
 	current, err := fctx.findExistingRouter(ctx)
 	if err != nil {
@@ -210,7 +215,6 @@ func (fctx *FlowContext) findFloatingPoolSubnetName() *string {
 	}
 
 	// Second: Check if the CloudProfile contains a default floating subnet and use it.
-	//nolint:staticcheck // SA1019: needed for migration purposes
 	if floatingPool, err := helper.FindFloatingPool(fctx.cloudProfileConfig.Constraints.FloatingPools, fctx.config.FloatingPoolName, fctx.infra.Spec.Region, nil); err == nil && floatingPool.DefaultFloatingSubnet != nil {
 		return floatingPool.DefaultFloatingSubnet
 	}

--- a/pkg/controller/infrastructure/openstack/infraflow/utils.go
+++ b/pkg/controller/infrastructure/openstack/infraflow/utils.go
@@ -59,7 +59,7 @@ func (fctx *FlowContext) defaultSecurityGroupName() string {
 }
 
 func (fctx *FlowContext) workerCIDR() string {
-	//nolint:staticcheck // SA1019: needed for migration purposes
+	//nolint:staticcheck // SA1019: deprecated will be removed later
 	s := fctx.config.Networks.Worker
 	if workers := fctx.config.Networks.Workers; workers != "" {
 		s = workers

--- a/pkg/controller/infrastructure/stackit/infraflow/context.go
+++ b/pkg/controller/infrastructure/stackit/infraflow/context.go
@@ -164,8 +164,11 @@ func (fctx *FlowContext) computeInfrastructureStatus() *stackitv1alpha1.Infrastr
 	status.Networks.ID = ptr.Deref(fctx.state.Get(IdentifierNetwork), "")
 	status.Networks.Name = ptr.Deref(fctx.state.Get(NameNetwork), "")
 
+	//nolint:staticcheck // SA1019: TODO
+	// TODO we need to save this in a different place as we need this later in the status of the Infrastructure Object for ACLs
 	status.Networks.Router.ExternalFixedIPs = fctx.state.GetObject(IdentifierEgressCIDRs).([]string)
 	// backwards compatibility change for the deprecated field
+	//nolint:staticcheck // SA1019: needed for migration purposes
 	if len(status.Networks.Router.ExternalFixedIPs) > 0 {
 		//nolint:staticcheck // SA1019: needed for migration purposes
 		status.Networks.Router.IP = status.Networks.Router.ExternalFixedIPs[0]
@@ -179,7 +182,6 @@ func (fctx *FlowContext) computeInfrastructureStatus() *stackitv1alpha1.Infrastr
 
 	// TODO: Remove once migrated fully to IaaS API
 	if v := fctx.state.Get(IdentifierSubnet); v != nil {
-		//nolint:staticcheck // SA1019: Will be removed once OpenStack mcm support is dropped.
 		status.Networks.Subnets = []stackitv1alpha1.Subnet{
 			{
 				Purpose:        stackitv1alpha1.PurposeNodes,

--- a/pkg/controller/infrastructure/stackit/infraflow/context.go
+++ b/pkg/controller/infrastructure/stackit/infraflow/context.go
@@ -37,8 +37,6 @@ const (
 	NameSecGroup = "SecurityGroupName"
 	// IdentifierSubnet is the key for the subnet id
 	IdentifierSubnet = "Subnet"
-	// IdentifierEgressCIDRs is the key for the slice containing egress CIDRs strings.
-	IdentifierEgressCIDRs = "EgressCIDRs"
 	// NameKeyPair is the key for the name of the EC2 key pair resource
 	NameKeyPair = "KeyPair"
 )
@@ -73,6 +71,7 @@ type FlowContext struct {
 	networking              osclient.Networking
 	isSNAShoot              bool
 	nodesCIDR               *string
+	egressCIDRs             []string
 	dnsNameservers          *[]string
 	stackitLB               stackitclient.LoadBalancingClient
 	stackitALB              stackitclient.ApplicationLoadBalancingClient
@@ -152,8 +151,8 @@ func NewFlowContext(ctx context.Context, opts Opts) (*FlowContext, error) {
 }
 
 func (fctx *FlowContext) persistState(ctx context.Context) error {
-	// status is nil such that there's no need to pass the nodesCIDR
-	return infrainternal.PatchProviderStatusAndState(ctx, fctx.client, fctx.infra, nil, nil, fctx.computeInfrastructureState())
+	// status is nil such that there's no need to pass the nodesCIDR and egressCIDRs
+	return infrainternal.PatchProviderStatusAndState(ctx, fctx.client, fctx.infra, nil, nil, nil, fctx.computeInfrastructureState())
 }
 
 func (fctx *FlowContext) computeInfrastructureStatus() *stackitv1alpha1.InfrastructureStatus {
@@ -163,16 +162,6 @@ func (fctx *FlowContext) computeInfrastructureStatus() *stackitv1alpha1.Infrastr
 
 	status.Networks.ID = ptr.Deref(fctx.state.Get(IdentifierNetwork), "")
 	status.Networks.Name = ptr.Deref(fctx.state.Get(NameNetwork), "")
-
-	//nolint:staticcheck // SA1019: TODO
-	// TODO we need to save this in a different place as we need this later in the status of the Infrastructure Object for ACLs
-	status.Networks.Router.ExternalFixedIPs = fctx.state.GetObject(IdentifierEgressCIDRs).([]string)
-	// backwards compatibility change for the deprecated field
-	//nolint:staticcheck // SA1019: needed for migration purposes
-	if len(status.Networks.Router.ExternalFixedIPs) > 0 {
-		//nolint:staticcheck // SA1019: needed for migration purposes
-		status.Networks.Router.IP = status.Networks.Router.ExternalFixedIPs[0]
-	}
 
 	status.Node.KeyName = ptr.Deref(fctx.state.Get(NameKeyPair), "")
 

--- a/pkg/controller/infrastructure/stackit/infraflow/context.go
+++ b/pkg/controller/infrastructure/stackit/infraflow/context.go
@@ -25,10 +25,6 @@ import (
 
 const (
 
-	// NameFloatingNetwork is the key for the floating network name
-	NameFloatingNetwork = "FloatingNetworkName"
-	// IdentifierFloatingNetwork is the key for the floating network id
-	IdentifierFloatingNetwork = "FloatingNetwork"
 	// IdentifierNetwork is the key for the network id
 	IdentifierNetwork = "Network"
 	// NameNetwork is the name of the network
@@ -164,9 +160,6 @@ func (fctx *FlowContext) computeInfrastructureStatus() *stackitv1alpha1.Infrastr
 	status := &stackitv1alpha1.InfrastructureStatus{
 		TypeMeta: infrainternal.StatusTypeMeta,
 	}
-
-	status.Networks.FloatingPool.ID = ptr.Deref(fctx.state.Get(IdentifierFloatingNetwork), "")
-	status.Networks.FloatingPool.Name = ptr.Deref(fctx.state.Get(NameFloatingNetwork), "")
 
 	status.Networks.ID = ptr.Deref(fctx.state.Get(IdentifierNetwork), "")
 	status.Networks.Name = ptr.Deref(fctx.state.Get(NameNetwork), "")

--- a/pkg/controller/infrastructure/stackit/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/stackit/infraflow/reconcile.go
@@ -16,6 +16,7 @@ import (
 	infrainternal "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/internal/infrastructure"
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit"
 	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/stackit/client"
+	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/utils"
 )
 
 const (
@@ -33,7 +34,7 @@ func (fctx *FlowContext) Reconcile(ctx context.Context) error {
 
 	state := fctx.computeInfrastructureState()
 	status := fctx.computeInfrastructureStatus()
-	return infrainternal.PatchProviderStatusAndState(ctx, fctx.client, fctx.infra, status, fctx.nodesCIDR, state)
+	return infrainternal.PatchProviderStatusAndState(ctx, fctx.client, fctx.infra, status, fctx.nodesCIDR, fctx.egressCIDRs, state)
 }
 
 func (fctx *FlowContext) buildReconcileGraph() *flow.Graph {
@@ -400,7 +401,6 @@ func (fctx *FlowContext) ensureIsolatedNetwork(ctx context.Context) error {
 }
 
 func (fctx *FlowContext) ensureEgressIP(ctx context.Context) error {
-	var result []string
 	networkID := fctx.state.Get(IdentifierNetwork)
 	network, err := fctx.iaasClient.GetNetworkById(ctx, *networkID)
 	if err != nil {
@@ -412,8 +412,7 @@ func (fctx *FlowContext) ensureEgressIP(ctx context.Context) error {
 	}
 	routerIP, ok := network.Ipv4.GetPublicIpOk()
 	if ok && routerIP != nil {
-		result = append(result, *routerIP)
-		fctx.state.SetObject(IdentifierEgressCIDRs, result)
+		fctx.egressCIDRs = utils.ComputeEgressCIDRs([]string{*routerIP})
 		return nil
 	}
 	return fmt.Errorf("egress IP not found for network: %s", network.GetId())

--- a/pkg/controller/infrastructure/stackit/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/stackit/infraflow/reconcile.go
@@ -39,16 +39,9 @@ func (fctx *FlowContext) Reconcile(ctx context.Context) error {
 func (fctx *FlowContext) buildReconcileGraph() *flow.Graph {
 	g := flow.NewGraph("STACKIT infrastructure reconciliation")
 
-	ensureExternalNetwork := fctx.AddTask(g, "ensure external network",
-		fctx.ensureExternalNetwork,
-		shared.Timeout(defaultTimeout),
-		shared.DoIf(fctx.hasOpenStackCredentials),
-	)
-
 	ensureNetwork := fctx.AddTask(g, "ensure isolated network",
 		fctx.ensureNetwork,
-		shared.Timeout(defaultTimeout),
-		shared.Dependencies(ensureExternalNetwork))
+		shared.Timeout(defaultTimeout))
 
 	_ = fctx.AddTask(g, "ensure openstack subnet id",
 		fctx.ensureOpenStackSubnetID,
@@ -80,19 +73,6 @@ func (fctx *FlowContext) buildReconcileGraph() *flow.Graph {
 		shared.Timeout(defaultTimeout), shared.Dependencies(ensureNetwork))
 
 	return g
-}
-
-func (fctx *FlowContext) ensureExternalNetwork(ctx context.Context) error {
-	externalNetwork, err := fctx.networking.GetExternalNetworkByName(ctx, fctx.config.FloatingPoolName)
-	if err != nil {
-		return err
-	}
-	if externalNetwork == nil {
-		return fmt.Errorf("external network for floating pool name %s not found", fctx.config.FloatingPoolName)
-	}
-	fctx.state.Set(IdentifierFloatingNetwork, externalNetwork.ID)
-	fctx.state.Set(NameFloatingNetwork, externalNetwork.Name)
-	return nil
 }
 
 func (fctx *FlowContext) ensureConfiguredNetwork(ctx context.Context) error {

--- a/pkg/controller/infrastructure/stackit/infraflow/utils.go
+++ b/pkg/controller/infrastructure/stackit/infraflow/utils.go
@@ -11,7 +11,7 @@ import (
 var ErrorMultipleMatches = fmt.Errorf("error multiple matches")
 
 func (fctx *FlowContext) workerCIDR() string {
-	//nolint:staticcheck // SA1019: needed for migration purposes
+	//nolint:staticcheck // SA1019: deprecated will be removed later
 	s := fctx.config.Networks.Worker
 	if workers := fctx.config.Networks.Workers; workers != "" {
 		s = workers

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -96,7 +96,6 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 	var subnet *stackitv1alpha1.Subnet
 	// There is no subnet resource in the IaaS API. The machine-controller-manager-provider-stackit do not require this field.
 	if !feature.UseStackitMachineControllerManager(w.cluster) {
-		//nolint:staticcheck // SA1019: Will be removed once we drop OpenStack API support
 		subnet, err = helper.FindSubnetByPurpose(infrastructureStatus.Networks.Subnets, stackitv1alpha1.PurposeNodes)
 		if err != nil {
 			return err

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -145,7 +145,6 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 		}
 
 		machineLabels := map[string]string{}
-		//nolint:staticcheck
 		for _, pair := range workerConfig.MachineLabels {
 			machineLabels[pair.Name] = pair.Value
 		}
@@ -310,7 +309,6 @@ func (w *workerDelegate) generateWorkerPoolHash(pool extensionsv1alpha1.WorkerPo
 	var additionalHashData []string
 
 	var pairs []string
-	//nolint:staticcheck
 	for _, pair := range workerConfig.MachineLabels {
 		if pair.TriggerRollingOnUpdate {
 			pairs = append(pairs, pair.Name+"="+pair.Value)

--- a/pkg/internal/infrastructure/infrastucture.go
+++ b/pkg/internal/infrastructure/infrastucture.go
@@ -148,7 +148,7 @@ func WorkersCIDR(config *stackitv1alpha1.InfrastructureConfig) string {
 	workersCIDR := config.Networks.Workers
 	// Backwards compatibility - remove this code in a future version.
 	if workersCIDR == "" {
-		//nolint:staticcheck // SA1019: needed for migration purposes
+		//nolint:staticcheck // SA1019: deprecated will be removed later
 		workersCIDR = config.Networks.Worker
 	}
 
@@ -168,6 +168,8 @@ func PatchProviderStatusAndState(
 	if status != nil {
 		infra.Status.ProviderStatus = &runtime.RawExtension{Object: status}
 		infra.Status.NodesCIDR = nodesCIDR
+		//nolint:staticcheck // SA1019: TODO
+		// TODO: We need a different source for this as the Router is deprecated
 		infra.Status.EgressCIDRs = utils.ComputeEgressCIDRs(status.Networks.Router.ExternalFixedIPs)
 	}
 

--- a/pkg/internal/infrastructure/infrastucture.go
+++ b/pkg/internal/infrastructure/infrastucture.go
@@ -24,7 +24,6 @@ import (
 
 	stackitv1alpha1 "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/apis/stackit/v1alpha1"
 	openstackclient "github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/openstack/client"
-	"github.com/stackitcloud/gardener-extension-provider-stackit/v2/pkg/utils"
 )
 
 const (
@@ -162,15 +161,14 @@ func PatchProviderStatusAndState(
 	infra *extensionsv1alpha1.Infrastructure,
 	status *stackitv1alpha1.InfrastructureStatus,
 	nodesCIDR *string,
+	egressCIDRs []string,
 	state *runtime.RawExtension,
 ) error {
 	patch := client.MergeFrom(infra.DeepCopy())
 	if status != nil {
 		infra.Status.ProviderStatus = &runtime.RawExtension{Object: status}
 		infra.Status.NodesCIDR = nodesCIDR
-		//nolint:staticcheck // SA1019: TODO
-		// TODO: We need a different source for this as the Router is deprecated
-		infra.Status.EgressCIDRs = utils.ComputeEgressCIDRs(status.Networks.Router.ExternalFixedIPs)
+		infra.Status.EgressCIDRs = egressCIDRs
 	}
 
 	if state != nil {

--- a/pkg/webhook/cloudprovider/ensurer.go
+++ b/pkg/webhook/cloudprovider/ensurer.go
@@ -62,17 +62,14 @@ func (e *ensurer) EnsureCloudProviderSecret(
 
 	// If no KeyStone configuration is present at all, skip KeyStone-related fields.
 	// This is valid for STACKIT-only shoots that don't require OpenStack credentials.
-	//nolint:staticcheck // SA1019: needed for migration purposes
 	if len(config.KeyStoneURLs) == 0 && len(config.KeyStoneURL) == 0 {
 		return nil
 	}
 
-	//nolint:staticcheck // SA1019: needed for migration purposes
 	keyStoneURL, err := helper.FindKeyStoneURL(config.KeyStoneURLs, config.KeyStoneURL, cluster.Shoot.Spec.Region)
 	if err != nil {
 		return fmt.Errorf("could not find KeyStoneUrl: %v", err)
 	}
-	//nolint:staticcheck // SA1019: needed for migration purposes
 	keyStoneCABundle := helper.FindKeyStoneCACert(config.KeyStoneURLs, config.KeyStoneCACert, cluster.Shoot.Spec.Region)
 
 	if new.Data == nil {
@@ -85,7 +82,6 @@ func (e *ensurer) EnsureCloudProviderSecret(
 
 	// remove key from user
 	delete(new.Data, types.Insecure)
-	//nolint:staticcheck // SA1019: needed for migration purposes
 	if config.KeyStoneForceInsecure {
 		new.Data[types.Insecure] = []byte("true")
 	}

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -409,6 +409,5 @@ func getResolveConfOptions(cloudProfileConfig *stackitv1alpha1.CloudProfileConfi
 	if cloudProfileConfig == nil {
 		return nil
 	}
-	//nolint:staticcheck // SA1019: needed for migration purposes
 	return cloudProfileConfig.ResolvConfOptions
 }

--- a/test/integration/infrastructure/stackit/infrastructure_test.go
+++ b/test/integration/infrastructure/stackit/infrastructure_test.go
@@ -640,17 +640,6 @@ func verifyCreation(infraStatus extensionsv1alpha1.InfrastructureStatus, provide
 	net, err := iaasClient.GetNetworkById(ctx, providerStatus.Networks.ID)
 	Expect(err).NotTo(HaveOccurred())
 
-	var externalFixedIPs []string
-	ip, ok := net.Ipv4.GetPublicIpOk()
-	if ok && ip != nil {
-		externalFixedIPs = append(externalFixedIPs, *ip)
-	}
-
-	// verify router ip in status
-	Expect(ip).NotTo(BeNil())
-	Expect(*ip).NotTo(BeEmpty())
-	Expect(providerStatus.Networks.Router.ExternalFixedIPs).To(ContainElements(externalFixedIPs))
-
 	// network is created
 	Expect(err).NotTo(HaveOccurred())
 	Expect(net).NotTo(BeNil())
@@ -672,7 +661,11 @@ func verifyCreation(infraStatus extensionsv1alpha1.InfrastructureStatus, provide
 	infrastructureIdentifier.keyPair = new(keyPair.GetName())
 
 	// verify egressCIDRs
-	Expect(infraStatus.EgressCIDRs).To(ContainElements(utils.ComputeEgressCIDRs(providerStatus.Networks.Router.ExternalFixedIPs)))
+	ip, ok := net.Ipv4.GetPublicIpOk()
+	Expect(ok).To(BeTrue())
+	Expect(ip).NotTo(BeNil())
+	Expect(*ip).NotTo(BeEmpty())
+	Expect(infraStatus.EgressCIDRs).To(ContainElements(utils.ComputeEgressCIDRs([]string{*ip})))
 
 	return infrastructureIdentifier, providerStatus
 }


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement
/cc @stackitcloud/ske-infrastructure 

**What this PR does / why we need it**:
This is a followup from #280.

The `floatingPoolName` was required but never used in a STACKIT only Cluster (since the validation is in place #212). It is only used in the STACKIT Infra-Controller in case there are OpenStack Credentials to pull the IDs of it in the Status.

The #280 PR removed the validation. This PR removes that the FloatingNetID is get via OpenStack in the STACKIT Infra-Controller (even if there are OpenStack Credenitals), as there is no need for it. This PR sets all only OpenStack fields in the Infrastructure to Depreciated. In OpenStack we save the EgressIPs in the provider status of the Infrastructure object to put it later in the Infrastructure Object. This is now done directly via context for STACKIT to not use the unneeded deprecated field in STACKIT Infra Controller.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
