### PR TITLE
regression: fix accidentally removed customLabelDomain unit-test

### DIFF
--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -1066,6 +1066,43 @@ var _ = Describe("Machines", func() {
 				Expect(result[1].ClusterAutoscalerAnnotations[extensionsv1alpha1.ScaleDownUnreadyTimeAnnotation]).To(Equal("3m0s"))
 				Expect(result[1].ClusterAutoscalerAnnotations[extensionsv1alpha1.ScaleDownUtilizationThresholdAnnotation]).To(Equal("0.5"))
 			})
+			DescribeTable("customLabelDomain in machineclass helm chart",
+				func(customDomain string) {
+					workerDelegate, _ := NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster, customDomain)
+
+					machineClassPath := filepath.Join("internal", "machineclass")
+					if useStackitMCM {
+						machineClassPath = filepath.Join("internal", "machineclass-stackit")
+					}
+
+					chartApplier.
+						EXPECT().
+						ApplyFromEmbeddedFS(
+							ctx,
+							charts.InternalChart,
+							machineClassPath,
+							namespace,
+							"machineclass",
+							gomock.Any(),
+						).
+						Return(nil)
+
+					err := workerDelegate.DeployMachineClasses(ctx)
+					Expect(err).NotTo(HaveOccurred())
+				},
+				Entry("with default kubernetes.io domain",
+					"kubernetes.io",
+				),
+				Entry("with custom ske.stackit.cloud domain",
+					"ske.stackit.cloud",
+				),
+				Entry("with custom example.com domain",
+					"example.com",
+				),
+				Entry("with empty domain",
+					"",
+				),
+			)
 			It("should distribute autoPreserveFailedMachineMax across zones", func() {
 				w.Spec.Pools[0].MachineControllerManagerSettings = &gardencorev1beta1.MachineControllerManagerSettings{
 					AutoPreserveFailedMachineMax: new(int32(4)),


### PR DESCRIPTION
**How to categorize this PR?**

/kind regression

**What this PR does / why we need it**:

Test was accidentally removed in #206 . Re-added now.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
