### PR TITLE
feat: use cloud profile storage type and size as defaults for machineclasses

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -205,6 +205,20 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			// specifying the volume type requires a custom volume size to be specified too.
 			if pool.Volume != nil && pool.Volume.Type != nil {
 				machineClassSpec["rootDiskType"] = *pool.Volume.Type
+			} else if machineTypeFromCloudProfile != nil &&
+				machineTypeFromCloudProfile.Storage != nil &&
+				machineTypeFromCloudProfile.Storage.Type != "" &&
+				machineTypeFromCloudProfile.Storage.Type != "default" {
+				// Use the storage type from the cloud profile as the default if not explicitly set in the shoot spec.
+				machineClassSpec["rootDiskType"] = machineTypeFromCloudProfile.Storage.Type
+				if machineTypeFromCloudProfile.Storage.StorageSize != nil {
+					cloudProfileVolumeSize, err := worker.DiskSize(machineTypeFromCloudProfile.Storage.StorageSize.String())
+					if err == nil && cloudProfileVolumeSize > 0 {
+						if _, alreadySet := machineClassSpec["rootDiskSize"]; !alreadySet {
+							machineClassSpec["rootDiskSize"] = cloudProfileVolumeSize
+						}
+					}
+				}
 			}
 
 			if machineImage.ID != "" {

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -6,6 +6,7 @@ package worker_test
 
 import (
 	"context"
+	"embed"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -32,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -1138,6 +1140,72 @@ var _ = Describe("Machines", func() {
 				Expect(result).NotTo(BeNil())
 				Expect(result[0].AutoPreserveFailedMachineMax).To(Equal(int32(0)))
 				Expect(result[1].AutoPreserveFailedMachineMax).To(Equal(int32(0)))
+			})
+			It("should use storage type and size from cloud profile machine type as default when no pool volume is specified", func() {
+				premiumStorageSize := resource.MustParse("64Gi")
+				clusterWithPremiumMachineType := &extensionscontroller.Cluster{
+					CloudProfile: cluster.CloudProfile.DeepCopy(),
+					Shoot:        cluster.Shoot,
+					Seed:         cluster.Seed,
+				}
+				clusterWithPremiumMachineType.CloudProfile.Spec.MachineTypes = []gardencorev1beta1.MachineType{
+					{
+						Name:         machineType,
+						Capabilities: capabilitiesAmd,
+						Storage: &gardencorev1beta1.MachineTypeStorage{
+							Class:       "standard",
+							StorageSize: &premiumStorageSize,
+							Type:        "premium",
+						},
+					},
+					{
+						Name:         machineTypeArm,
+						Architecture: ptr.To(archARM),
+						Capabilities: capabilitiesArm,
+					},
+				}
+
+				machineClassPath := filepath.Join("internal", "machineclass")
+				if useStackitMCM {
+					machineClassPath = filepath.Join("internal", "machineclass-stackit")
+				}
+
+				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, clusterWithPremiumMachineType, customLabelDomain)
+
+				var capturedMachineClasses []map[string]interface{}
+				chartApplier.
+					EXPECT().
+					ApplyFromEmbeddedFS(
+						ctx,
+						charts.InternalChart,
+						machineClassPath,
+						namespace,
+						"machineclass",
+						gomock.AssignableToTypeOf(kubernetes.Values(nil)),
+					).
+					DoAndReturn(func(_ context.Context, _ embed.FS, _, _, _ string, opts ...kubernetes.ApplyOption) error {
+						applyOpts := &kubernetes.ApplyOptions{}
+						for _, o := range opts {
+							o.MutateApplyOptions(applyOpts)
+						}
+						if values, ok := applyOpts.Values.(map[string]interface{}); ok {
+							if classes, ok := values["machineClasses"].([]map[string]interface{}); ok {
+								capturedMachineClasses = classes
+							}
+						}
+						return nil
+					})
+
+				err := workerDelegate.DeployMachineClasses(ctx)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(capturedMachineClasses).NotTo(BeEmpty())
+				for _, class := range capturedMachineClasses {
+					if class["machineType"] == machineType {
+						Expect(class).To(HaveKeyWithValue("rootDiskType", "premium"), "expected rootDiskType to be set from cloud profile storage type")
+						Expect(class).To(HaveKeyWithValue("rootDiskSize", 64), "expected rootDiskSize to be set from cloud profile storage size")
+					}
+				}
 			})
 		},
 			Entry("with capabilities and using imageIDs", true, false, false),

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -33,7 +33,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -1160,7 +1159,7 @@ var _ = Describe("Machines", func() {
 					},
 					{
 						Name:         machineTypeArm,
-						Architecture: ptr.To(archARM),
+						Architecture: new(archARM),
 						Capabilities: capabilitiesArm,
 					},
 				}
@@ -1172,7 +1171,7 @@ var _ = Describe("Machines", func() {
 
 				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, clusterWithPremiumMachineType, customLabelDomain)
 
-				var capturedMachineClasses []map[string]interface{}
+				var capturedMachineClasses []map[string]any
 				chartApplier.
 					EXPECT().
 					ApplyFromEmbeddedFS(
@@ -1188,8 +1187,8 @@ var _ = Describe("Machines", func() {
 						for _, o := range opts {
 							o.MutateApplyOptions(applyOpts)
 						}
-						if values, ok := applyOpts.Values.(map[string]interface{}); ok {
-							if classes, ok := values["machineClasses"].([]map[string]interface{}); ok {
+						if values, ok := applyOpts.Values.(map[string]any); ok {
+							if classes, ok := values["machineClasses"].([]map[string]any); ok {
 								capturedMachineClasses = classes
 							}
 						}


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement


**What this PR does / why we need it**:

See Title, pretty self explanatory. Add's better defaulting if not set especially in `MachineClass`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
